### PR TITLE
Added memory reporting

### DIFF
--- a/lib/BenchIteration.php
+++ b/lib/BenchIteration.php
@@ -13,9 +13,13 @@ namespace PhpBench;
 
 class BenchIteration
 {
-    protected $index;
-    protected $parameters;
-    protected $time;
+    private $index;
+    private $parameters;
+    private $time;
+    private $memory;
+    private $memoryDiff;
+    private $memoryInclusive;
+    private $memoryDiffInclusive;
 
     public function __construct($index, $parameters)
     {
@@ -52,5 +56,45 @@ class BenchIteration
     public function setTime($time)
     {
         $this->time = $time;
+    }
+
+    public function getMemory() 
+    {
+        return $this->memory;
+    }
+    
+    public function setMemory($memory)
+    {
+        $this->memory = $memory;
+    }
+
+    public function getMemoryDiff() 
+    {
+        return $this->memoryDiff;
+    }
+    
+    public function setMemoryDiff($memoryDiff)
+    {
+        $this->memoryDiff = $memoryDiff;
+    }
+
+    public function getMemoryInclusive() 
+    {
+        return $this->memoryInclusive;
+    }
+    
+    public function setMemoryInclusive($memoryInclusive)
+    {
+        $this->memoryInclusive = $memoryInclusive;
+    }
+
+    public function getMemoryDiffInclusive() 
+    {
+        return $this->memoryDiffInclusive;
+    }
+    
+    public function setMemoryDiffInclusive($memoryDiffInclusive)
+    {
+        $this->memoryDiffInclusive = $memoryDiffInclusive;
     }
 }

--- a/lib/Console/Command/BenchRunCommand.php
+++ b/lib/Console/Command/BenchRunCommand.php
@@ -55,10 +55,15 @@ EOT
         $path = $input->getArgument('path');
         $filter = $input->getOption('filter');
 
+        $startTime = microtime(true);
         $results = $this->executeBenchmarks($output, $path, $filter);
+
         $output->writeln('');
 
         $this->generateReports($output, $results, $reportConfigs);
+
+        $output->writeln(sprintf('Done (%s)', number_format(microtime(true) - $startTime, 6)));
+        $output->writeln('');
     }
 
     private function generateReports(OutputInterface $output, BenchCaseCollectionResult $results, $reportConfigs)
@@ -146,7 +151,6 @@ EOT
 
         if (is_dir($path)) {
             $finder->in($path);
-            $finder->name('*Case.php');
         } else {
             $finder->in(dirname($path));
             $finder->name(basename($path));

--- a/lib/ReportGenerator/BaseTabularReportGenerator.php
+++ b/lib/ReportGenerator/BaseTabularReportGenerator.php
@@ -24,6 +24,8 @@ abstract class BaseTabularReportGenerator implements BenchReportGenerator
             'aggregate_iterations' => false,
             'precision' => 8,
             'explode_param' => null,
+            'memory' => false,
+            'memory_inc' => false,
         ));
 
         $options->setAllowedTypes('aggregate_iterations', 'boolean');
@@ -56,6 +58,10 @@ abstract class BaseTabularReportGenerator implements BenchReportGenerator
                     $options['aggregate_iterations'] ? $aggregateResult->getAverageTime() : $iteration->getTime(),
                     $this->precision
                 );
+                $row['memory'] = number_format($iteration->getMemory());
+                $row['memory_diff'] = ($iteration->getMemoryDiff() > 0 ? '+' : '') . number_format($iteration->getMemoryDiff());
+                $row['memory_inc'] = number_format($iteration->getMemoryInclusive());
+                $row['memory_diff_inc'] = ($iteration->getMemoryDiffInclusive() > 0 ? '+' : '') . number_format($iteration->getMemoryDiffInclusive());
                 $row['min_time'] = number_format($aggregateResult->getMinTime(), $this->precision);
                 $row['max_time'] = number_format($aggregateResult->getMaxTime(), $this->precision);
                 $row['total_time'] = number_format($aggregateResult->getTotalTime(), $this->precision);
@@ -84,8 +90,22 @@ abstract class BaseTabularReportGenerator implements BenchReportGenerator
 
             if ($options['aggregate_iterations']) {
                 unset($row['iter']);
+                unset($row['memory']);
+                unset($row['memory_inc']);
+                unset($row['memory_diff']);
+                unset($row['memory_diff_inc']);
             } else {
                 unset($row['iters']);
+            }
+
+            if (false === $options['memory']) {
+                unset($row['memory']);
+                unset($row['memory_diff']);
+            }
+
+            if (false === $options['memory_inc']) {
+                unset($row['memory_inc']);
+                unset($row['memory_diff_inc']);
             }
         }
 

--- a/tests/Functional/ReportGenerator/BaseTabularReportGeneratorCase.php
+++ b/tests/Functional/ReportGenerator/BaseTabularReportGeneratorCase.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the PHP Bench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PhpBench\Functional\ReportGenerator;
+
+
+abstract class BaseTabularReportGeneratorCase extends BaseReportGeneratorCase
+{
+    /**
+     * It should run without any options.
+     */
+    public function testNoOptions()
+    {
+        $this->executeReport($this->getResults(), array());
+    }
+
+    /**
+     * It should change the precision.
+     */
+    public function testWithPrecision()
+    {
+        $this->executeReport($this->getResults(), array(
+            'precision' => 2,
+        ));
+    }
+
+    /**
+     * It should change aggregate iterations.
+     */
+    public function testWithAggregateIterations()
+    {
+        $this->executeReport($this->getResults(), array(
+            'aggregate_iterations' => true,
+        ));
+    }
+
+    /**
+     * It should allow explode_param.
+     */
+    public function testWithExplodeParam()
+    {
+        $this->executeReport($this->getResults(), array(
+            'explode_param' => 'foo',
+        ));
+    }
+
+    /**
+     * It should allow memory
+     */
+    public function testWithMemory()
+    {
+        $this->executeReport($this->getResults(), array(
+            'memory' => true,
+        ));
+    }
+
+    /**
+     * It should allow memory inclusive
+     */
+    public function testWithMemoryInclusive()
+    {
+        $this->executeReport($this->getResults(), array(
+            'memory_inc' => true,
+        ));
+    }
+}

--- a/tests/Functional/ReportGenerator/XmlReportGeneratorTest.php
+++ b/tests/Functional/ReportGenerator/XmlReportGeneratorTest.php
@@ -13,13 +13,14 @@ namespace PhpBench\Functional\ReportGenerator;
 
 use PhpBench\ReportGenerator\ConsoleTableReportGenerator;
 use Symfony\Component\Console\Output\NullOutput;
+use PhpBench\ReportGenerator\XmlTableReportGenerator;
 
-class ConsoleReportGeneratorTest extends BaseTabularReportGeneratorCase
+class XmlReportGeneratorTest extends BaseTabularReportGeneratorCase
 {
     public function getReport()
     {
         $output = new NullOutput();
 
-        return new ConsoleTableReportGenerator($output);
+        return new XmlTableReportGenerator($output);
     }
 }


### PR DESCRIPTION
Added support for reporting memory:

````php
php ./bin/phpbench run tests/assets/functional --report='{"name": "console_table", "memory": true, "memory_inc": true}'
Running benchmarking suite

BenchmarkCase
...

Generating reports...

>> console_table >>

BenchmarkCase#benchParameterized(): Parameterized bench mark
+------+--------+----------+------------+--------+-------------+------------+-----------------+
| iter | length | strategy | time       | memory | memory_diff | memory_inc | memory_diff_inc |
+------+--------+----------+------------+--------+-------------+------------+-----------------+
| 1    | 1      | left     | 0.00001287 | 144    | +144        | 2,795,304  | +5,688          |
| 1    | 2      | left     | 0.00001192 | 288    | +144        | 2,796,656  | +1,352          |
| 1    | 1      | right    | 0.00001192 | 432    | +144        | 2,798,024  | +1,368          |
| 1    | 2      | right    | 0.00001192 | 576    | +144        | 2,799,392  | +1,368          |
+------+--------+----------+------------+--------+-------------+------------+-----------------+
````

- `memory` + `memory_diff`: Relates to memory used by the code under test
- `memory_inc` + `memory_diff_inc`: Relates to global memory usage including overhead from the framework and any `beforeMethods` used.