### PR TITLE
Introducing Configuration class

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,57 @@ BenchmarkCase#benchParameterized(): Parameterized bench mark
 +---+-----------------------------------+------------+
 ````
 
+Configuration
+-------------
+
+PhpBench supports configuration files, allowing you to configure and extend
+your reports.
+
+Configuration files are in plain PHP and MUST return a
+`Phpbench\Configuration` object and bootstrap the autoloader.
+
+Phpbench will first look for the file `.phpbench` and then `.phpbench.dist`.
+It is also possible to specify a configuration file with the ``--config``
+option.
+
+Below is the most minimal example:
+
+````php
+<?php
+// .phpbench
+
+require(__DIR__ . '/vendor/autoload.php');
+
+$configuration = new PhpBench\Configuration();
+
+return $configuraton;
+````
+
+And here is a full example:
+
+````php
+<?php
+// .phpbench
+
+require(__DIR__ . '/vendor/autoload.php');
+$configuration = new PhpBench\Configuration();
+
+// set the path in which to search for benchmarks
+$configuration->setPath(__DIR__ . '/benchmarks');
+
+// add a new report generator
+$configuration->addReportGenerator('my_report_generator', new MyReportGenerator());A
+
+// add a report
+$configuration->addReport(array(k
+    'name' => 'my_report_generator',
+    'option_1' => 'one',
+    'option_2' => 'two',
+));
+
+return $configuraton;
+````
+
 See also
 --------
 

--- a/bin/phpbench.php
+++ b/bin/phpbench.php
@@ -9,37 +9,63 @@
  * file that was distributed with this source code.
  */
 
-function includeIfExists($file)
-{
-    if (file_exists($file)) {
-        return include $file;
+require_once(__DIR__ . '/../lib/Benchmark/Configuration.php');
+
+use PhpBench\Benchmark\Configuration;
+
+$configPaths = array();
+
+foreach ($argv as $arg) {
+    if (0 === strpos($arg, '--config=')) {
+        $configFile = substr($arg, 9);
+        if (!file_exists($configFile)) {
+            echo sprintf('Config file "%s" does not exist', $configFile) . PHP_EOL;
+            exit(1);
+        }
+        $configPaths = array($configFile);
     }
 }
 
-$autoloadPath = getcwd() . '/vendor/autoload.php';
-$configPaths = array(
-    getcwd() . '/.phpbench',
-    getcwd() . '/.phpbench.dist',
-);
-
-if (!file_exists($autoloadPath)) {
-    fwrite(STDERR,
-        'You must execute phpbench from the project root and set up the project' .
-        'dependencies.'
+if (empty($configPaths)) {
+    $configPaths = array(
+        getcwd() . '/.phpbench',
+        getcwd() . '/.phpbench.dist',
     );
-    exit(1);
 }
 
+$configuration = null;
 foreach ($configPaths as $configPath) {
     if (file_exists($configPath)) {
-        require_once $configPath;
+        $configuration = require_once $configPath;
         break;
     }
 }
 
-require_once $autoloadPath;
+if (null === $configuration) {
+    $bootstrapPath = getcwd() . '/vendor/autoload.php';
+
+    if (!file_exists($bootstrapPath)) {
+        echo 'Autoload file "%s" does not exist. Maybe you need to do a composer install?' . PHP_EOL;
+        exit(1);
+    }
+
+    require_once $bootstrapPath;
+
+    $configuration = new Configuration();
+}
+
+if (!$configuration) {
+    echo 'The configuration file did not return anything. It must return an instance of PhpBench\\Configuration' . PHP_EOL;
+    exit(1);
+}
+
+if (!$configuration instanceof PhpBench\Benchmark\Configuration) {
+    echo 'The configuration file did not return an instance of PhpBench\\Configuration';
+    exit(1);
+}
 
 use PhpBench\Console\Application;
 
 $application = new Application();
+$application->setConfiguration($configuration);
 $application->run();

--- a/bin/phpbench.php
+++ b/bin/phpbench.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-require_once(__DIR__ . '/../lib/Configuration.php');
+require_once __DIR__ . '/../lib/Configuration.php';
 
 use PhpBench\Configuration;
 
@@ -53,7 +53,6 @@ if (null === $configuration) {
 
     $configuration = new Configuration();
 }
-
 
 if (!$configuration instanceof Configuration) {
     echo 'The configuration file did not return an instance of PhpBench\\Configuration';

--- a/bin/phpbench.php
+++ b/bin/phpbench.php
@@ -66,6 +66,5 @@ if (!$configuration instanceof PhpBench\Benchmark\Configuration) {
 
 use PhpBench\Console\Application;
 
-$application = new Application();
-$application->setConfiguration($configuration);
+$application = new Application($configuration);
 $application->run();

--- a/bin/phpbench.php
+++ b/bin/phpbench.php
@@ -45,7 +45,7 @@ if (null === $configuration) {
     $bootstrapPath = getcwd() . '/vendor/autoload.php';
 
     if (!file_exists($bootstrapPath)) {
-        echo 'Autoload file "%s" does not exist. Maybe you need to do a composer install?' . PHP_EOL;
+        echo sprintf('Autoload file "%s" does not exist. Maybe you need to do a composer install?', $bootstrapPath) . PHP_EOL;
         exit(1);
     }
 
@@ -54,10 +54,6 @@ if (null === $configuration) {
     $configuration = new Configuration();
 }
 
-if (!$configuration) {
-    echo 'The configuration file did not return anything. It must return an instance of PhpBench\\Configuration' . PHP_EOL;
-    exit(1);
-}
 
 if (!$configuration instanceof PhpBench\Benchmark\Configuration) {
     echo 'The configuration file did not return an instance of PhpBench\\Configuration';

--- a/bin/phpbench.php
+++ b/bin/phpbench.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-require_once(__DIR__ . '/../lib/Benchmark/Configuration.php');
+require_once(__DIR__ . '/../lib/Configuration.php');
 
-use PhpBench\Benchmark\Configuration;
+use PhpBench\Configuration;
 
 $configPaths = array();
 
@@ -55,7 +55,7 @@ if (null === $configuration) {
 }
 
 
-if (!$configuration instanceof PhpBench\Benchmark\Configuration) {
+if (!$configuration instanceof Configuration) {
     echo 'The configuration file did not return an instance of PhpBench\\Configuration';
     exit(1);
 }

--- a/bin/phpbench.php
+++ b/bin/phpbench.php
@@ -55,7 +55,7 @@ if (null === $configuration) {
 }
 
 if (!$configuration instanceof Configuration) {
-    echo 'The configuration file did not return an instance of PhpBench\\Configuration';
+    echo 'The configuration file did not return an instance of PhpBench\\Configuration' . PHP_EOL;
     exit(1);
 }
 

--- a/lib/Benchmark/Configuration.php
+++ b/lib/Benchmark/Configuration.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace PhpBench\Benchmark;
+
+use PhpBench\ReportGenerator;
+
+class Configuration
+{
+    private $reportGenerators = array();
+    private $path;
+    private $reports = array();
+
+    public function addReportGenerator($name, ReportGenerator $reportGenerator)
+    {
+        $this->reportGenerators[$name] = $reportGenerator;
+    }
+
+    public function getReportGenerators()
+    {
+        return $this->reportGenerators;
+    }
+
+    public function setPath($path)
+    {
+        $this->path = $path;
+    }
+
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    public function addReport($config)
+    {
+        $this->reports[] = $config;
+    }
+
+    public function getReports()
+    {
+        return $this->reports;
+    }
+
+    public function setReports($reports)
+    {
+        $this->reports = $reports;
+    }
+}

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -1,8 +1,15 @@
 <?php
 
-namespace PhpBench;
+/*
+ * This file is part of the PHP Bench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
-use PhpBench\ReportGenerator;
+namespace PhpBench;
 
 class Configuration
 {

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpBench\Benchmark;
+namespace PhpBench;
 
 use PhpBench\ReportGenerator;
 

--- a/lib/Console/Application.php
+++ b/lib/Console/Application.php
@@ -16,7 +16,7 @@ use PhpBench\Console\Command\RunCommand;
 use PhpBench\PhpBench;
 use PhpBench\Console\Command\ReportCommand;
 use Symfony\Component\Console\Input\InputInterface;
-use PhpBench\Benchmark\Configuration;
+use PhpBench\Configuration;
 use Symfony\Component\Console\Output\OutputInterface;
 use PhpBench\ReportGenerator\XmlTableReportGenerator;
 use Symfony\Component\Console\Input\InputOption;

--- a/lib/Console/Application.php
+++ b/lib/Console/Application.php
@@ -26,7 +26,7 @@ class Application extends BaseApplication
 {
     private $configuration;
 
-    public function __construct()
+    public function __construct(Configuration $configuration = null)
     {
         parent::__construct(
             'phpbench',
@@ -35,24 +35,15 @@ class Application extends BaseApplication
 
         $this->add(new RunCommand());
         $this->add(new ReportCommand());
-    }
 
-    public function setConfiguration(Configuration $configuration)
-    {
-        $this->configuration = $configuration;
-        $this->initConfiguration();
+        $this->configuration = $configuration ? : new Configuration();
+        $this->configuration->addReportGenerator('console_table', new ConsoleTableReportGenerator());
+        $this->configuration->addReportGenerator('xml_table', new XmlTableReportGenerator());
     }
 
     public function getConfiguration()
     {
         return $this->configuration;
-    }
-
-    public function initConfiguration()
-    {
-        $configuration = $this->getConfiguration();
-        $configuration->addReportGenerator('console_table', new ConsoleTableReportGenerator());
-        $configuration->addReportGenerator('xml_table', new XmlTableReportGenerator());
     }
 
     protected function getDefaultInputDefinition()

--- a/lib/Console/Application.php
+++ b/lib/Console/Application.php
@@ -15,9 +15,17 @@ use Symfony\Component\Console\Application as BaseApplication;
 use PhpBench\Console\Command\RunCommand;
 use PhpBench\PhpBench;
 use PhpBench\Console\Command\ReportCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use PhpBench\Benchmark\Configuration;
+use Symfony\Component\Console\Output\OutputInterface;
+use PhpBench\ReportGenerator\XmlTableReportGenerator;
+use Symfony\Component\Console\Input\InputOption;
+use PhpBench\ReportGenerator\ConsoleTableReportGenerator;
 
 class Application extends BaseApplication
 {
+    private $configuration;
+
     public function __construct()
     {
         parent::__construct(
@@ -27,5 +35,33 @@ class Application extends BaseApplication
 
         $this->add(new RunCommand());
         $this->add(new ReportCommand());
+    }
+
+    public function setConfiguration(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+        $this->initConfiguration();
+    }
+
+    public function getConfiguration()
+    {
+        return $this->configuration;
+    }
+
+    public function initConfiguration()
+    {
+        $configuration = $this->getConfiguration();
+        $configuration->addReportGenerator('console_table', new ConsoleTableReportGenerator());
+        $configuration->addReportGenerator('xml_table', new XmlTableReportGenerator());
+    }
+
+    protected function getDefaultInputDefinition()
+    {
+        $default = parent::getDefaultInputDefinition();
+        $default->addOptions(array(
+            new InputOption('--config', null, InputOption::VALUE_REQUIRED)
+        ));
+
+        return $default;
     }
 }

--- a/lib/Console/Application.php
+++ b/lib/Console/Application.php
@@ -15,9 +15,7 @@ use Symfony\Component\Console\Application as BaseApplication;
 use PhpBench\Console\Command\RunCommand;
 use PhpBench\PhpBench;
 use PhpBench\Console\Command\ReportCommand;
-use Symfony\Component\Console\Input\InputInterface;
 use PhpBench\Configuration;
-use Symfony\Component\Console\Output\OutputInterface;
 use PhpBench\ReportGenerator\XmlTableReportGenerator;
 use Symfony\Component\Console\Input\InputOption;
 use PhpBench\ReportGenerator\ConsoleTableReportGenerator;
@@ -36,7 +34,7 @@ class Application extends BaseApplication
         $this->add(new RunCommand());
         $this->add(new ReportCommand());
 
-        $this->configuration = $configuration ? : new Configuration();
+        $this->configuration = $configuration ?: new Configuration();
         $this->configuration->addReportGenerator('console_table', new ConsoleTableReportGenerator());
         $this->configuration->addReportGenerator('xml_table', new XmlTableReportGenerator());
     }
@@ -50,7 +48,7 @@ class Application extends BaseApplication
     {
         $default = parent::getDefaultInputDefinition();
         $default->addOptions(array(
-            new InputOption('--config', null, InputOption::VALUE_REQUIRED)
+            new InputOption('--config', null, InputOption::VALUE_REQUIRED),
         ));
 
         return $default;

--- a/lib/Console/Command/BaseCommand.php
+++ b/lib/Console/Command/BaseCommand.php
@@ -21,26 +21,27 @@ use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 
 abstract class BaseCommand extends Command
 {
-    protected function generateReports(OutputInterface $output, SuiteResult $results, $reportConfigs)
+    protected function generateReports(OutputInterface $output, SuiteResult $results)
     {
         $output->writeln('<info>Generating reports...</info>');
         $output->writeln('');
 
-        $generators = array(
-            'console_table' => new ConsoleTableReportGenerator($output),
-            'xml_table' => new XmlTableReportGenerator($output),
-        );
+        $configuration = $this->getApplication()->getConfiguration();
+        $generators = $configuration->getReportGenerators();
+        $reportConfigs = $configuration->getReports();
 
-        foreach ($reportConfigs as $reportName => $reportConfig) {
-            if (!isset($generators[$reportName])) {
+        foreach ($reportConfigs as $reportConfig) {
+            if (!isset($generators[$reportConfig['name']])) {
                 throw new \InvalidArgumentException(sprintf(
                     'Unknown report generator "%s", known generators: "%s"',
-                    $reportName, implode('", "', array_keys($generators))
+                    $reportConfig['name'], implode('", "', array_keys($generators))
                 ));
             }
         }
 
-        foreach ($reportConfigs as $reportName => $reportConfig) {
+        foreach ($reportConfigs as $reportConfig) {
+            $reportName = $reportConfig['name'];
+            unset($reportConfig['name']);
             $options = new OptionsResolver();
             $report = $generators[$reportName];
             $report->configure($options);
@@ -55,17 +56,19 @@ abstract class BaseCommand extends Command
                 ), null, $e);
             }
 
-            $report->generate($results, $reportConfig);
+            $report->generate($results, $output, $reportConfig);
         }
     }
 
-    protected function normalizeReportConfig($rawConfigs)
+    protected function processReportConfigs($rawConfigs)
     {
+        $configuration = $this->getApplication()->getConfiguration();
+
         $configs = array();
         foreach ($rawConfigs as $rawConfig) {
             // If it doesn't look like a JSON string, assume it is the name of a report
             if (substr($rawConfig, 0, 1) !== '{') {
-                $configs[$rawConfig] = array();
+                $configs[] = array('name' => $rawConfig);
                 continue;
             }
 
@@ -84,12 +87,12 @@ abstract class BaseCommand extends Command
                 ));
             }
 
-            $name = $config['name'];
-            unset($config['name']);
-
-            $configs[$name] = $config;
         }
 
-        return $configs;
+        if (!$configs) {
+            return;
+        }
+
+        $configuration->setReports($configs);
     }
 }

--- a/lib/Console/Command/BaseCommand.php
+++ b/lib/Console/Command/BaseCommand.php
@@ -87,6 +87,7 @@ abstract class BaseCommand extends Command
                 ));
             }
 
+            $configs[] = $config;
         }
 
         if (!$configs) {

--- a/lib/Console/Command/BaseCommand.php
+++ b/lib/Console/Command/BaseCommand.php
@@ -14,8 +14,6 @@ namespace PhpBench\Console\Command;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\OutputInterface;
 use PhpBench\Result\SuiteResult;
-use PhpBench\ReportGenerator\ConsoleTableReportGenerator;
-use PhpBench\ReportGenerator\XmlTableReportGenerator;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 

--- a/lib/Console/Command/ReportCommand.php
+++ b/lib/Console/Command/ReportCommand.php
@@ -38,12 +38,13 @@ EOT
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $reportConfigs = $this->normalizeReportConfig($input->getOption('report'));
+        $configuration = $this->getApplication()->getConfiguration();
+        $this->processReportConfigs($input->getOption('report'));
         $file = $input->getArgument('file');
 
-        if (!$reportConfigs) {
+        if (!$configuration->getReports()) {
             throw new \InvalidArgumentException(
-                'You must specify at least one report, e.g.: --report=console_table'
+                'You must specify or configure at least one report, e.g.: --report=console_table'
             );
         }
 
@@ -55,6 +56,6 @@ EOT
 
         $loader = new XmlLoader();
         $suiteResult = $loader->load(file_get_contents($file));
-        $this->generateReports($output, $suiteResult, $reportConfigs);
+        $this->generateReports($output, $suiteResult);
     }
 }

--- a/lib/Console/Command/RunCommand.php
+++ b/lib/Console/Command/RunCommand.php
@@ -54,7 +54,7 @@ EOT
         $configuration = $this->getApplication()->getConfiguration();
 
         $this->processReportConfigs($reports);
-        $path = $input->getArgument('path') ? : $configuration->getPath();
+        $path = $input->getArgument('path') ?: $configuration->getPath();
 
         if (null === $path) {
             throw new \InvalidArgumentException(

--- a/lib/Console/Command/RunCommand.php
+++ b/lib/Console/Command/RunCommand.php
@@ -38,7 +38,7 @@ Run benchmark files at given <comment>path</comment>
 All bench marks under the given path will be executed recursively.
 EOT
         );
-        $this->addArgument('path', InputArgument::REQUIRED, 'Path to benchmark(s)');
+        $this->addArgument('path', InputArgument::OPTIONAL, 'Path to benchmark(s)');
         $this->addOption('report', array(), InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Report name or configuration in JSON format');
         $this->addOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter subject(s) to run');
         $this->addOption('dumpfile', 'df', InputOption::VALUE_REQUIRED, 'Dump XML to named file');
@@ -46,11 +46,22 @@ EOT
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
+        $reports = $input->getOption('report');
+
         $output->writeln('<info>Running benchmark suite</info>');
         $output->writeln('');
-        $reportConfigs = $this->normalizeReportConfig($input->getOption('report'));
 
-        $path = $input->getArgument('path');
+        $configuration = $this->getApplication()->getConfiguration();
+
+        $this->processReportConfigs($reports);
+        $path = $input->getArgument('path') ? : $configuration->getPath();
+
+        if (null === $path) {
+            throw new \InvalidArgumentException(
+                'You must either specify or configure a path where your benchmarks can be found.'
+            );
+        }
+
         $filter = $input->getOption('filter');
         $dumpfile = $input->getOption('dumpfile');
 
@@ -65,8 +76,8 @@ EOT
             $output->writeln('');
         }
 
-        if ($reportConfigs) {
-            $this->generateReports($output, $result, $reportConfigs);
+        if ($configuration->getReports()) {
+            $this->generateReports($output, $result);
         }
 
         $output->writeln(sprintf('<info>Done </info>(%s)', number_format(microtime(true) - $startTime, 6)));

--- a/lib/ReportGenerator.php
+++ b/lib/ReportGenerator.php
@@ -13,10 +13,11 @@ namespace PhpBench;
 
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use PhpBench\Result\SuiteResult;
+use Symfony\Component\Console\Output\OutputInterface;
 
 interface ReportGenerator
 {
     public function configure(OptionsResolver $options);
 
-    public function generate(SuiteResult $collection, array $config);
+    public function generate(SuiteResult $collection, OutputInterface $output, array $config);
 }

--- a/lib/ReportGenerator/BaseTabularReportGenerator.php
+++ b/lib/ReportGenerator/BaseTabularReportGenerator.php
@@ -17,6 +17,7 @@ use PhpBench\Result\SubjectResult;
 use PhpBench\ReportGenerator;
 use DTL\DataTable\Table;
 use DTL\DataTable\Builder\TableBuilder;
+use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class BaseTabularReportGenerator implements ReportGenerator
 {
@@ -40,11 +41,11 @@ abstract class BaseTabularReportGenerator implements ReportGenerator
         $options->setAllowedTypes('precision', 'int');
     }
 
-    public function generate(SuiteResult $suite, array $options)
+    public function generate(SuiteResult $suite, OutputInterface $output, array $options)
     {
         $this->precision = $options['precision'];
 
-        return $this->doGenerate($suite, $options);
+        return $this->doGenerate($suite, $output, $options);
     }
 
     protected function prepareData(SubjectResult $subject, array $options)

--- a/lib/ReportGenerator/BaseTabularReportGenerator.php
+++ b/lib/ReportGenerator/BaseTabularReportGenerator.php
@@ -15,7 +15,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use PhpBench\Result\SuiteResult;
 use PhpBench\Result\SubjectResult;
 use PhpBench\ReportGenerator;
-use DTL\DataTable\Table;
 use DTL\DataTable\Builder\TableBuilder;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -86,7 +85,6 @@ abstract class BaseTabularReportGenerator implements ReportGenerator
             }
         }
 
-
         $data = $table->getTable();
 
         if (true === $options['aggregate_iterations']) {
@@ -95,8 +93,8 @@ abstract class BaseTabularReportGenerator implements ReportGenerator
                 foreach ($cols as $colName => $groups) {
                     $row->set('iters', count($table->getRows()));
                     $row->set('avg_' . $colName, $table->getColumn($colName)->avg(), $table->getColumn($colName)->getGroups());
-                    $row->set('min_' . $colName, $table->getColumn($colName)->min(), $table->getColumn($colName)->getGroups()); 
-                    $row->set('max_' . $colName, $table->getColumn($colName)->max(), $table->getColumn($colName)->getGroups()); 
+                    $row->set('min_' . $colName, $table->getColumn($colName)->min(), $table->getColumn($colName)->getGroups());
+                    $row->set('max_' . $colName, $table->getColumn($colName)->max(), $table->getColumn($colName)->getGroups());
                     $row->remove($colName);
                 }
             }, array('run'));

--- a/lib/ReportGenerator/ConsoleTableReportGenerator.php
+++ b/lib/ReportGenerator/ConsoleTableReportGenerator.php
@@ -19,25 +19,22 @@ use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 
 class ConsoleTableReportGenerator extends BaseTabularReportGenerator
 {
-    public function __construct(OutputInterface $output)
+    public function doGenerate(SuiteResult $suite, OutputInterface $output, array $options)
     {
-        $this->output = $output;
-        $this->output->getFormatter()->setStyle(
+        $output = $output;
+        $output->getFormatter()->setStyle(
             'total', new OutputFormatterStyle(null, null, array())
         );
-        $this->output->getFormatter()->setStyle(
+        $output->getFormatter()->setStyle(
             'blue', new OutputFormatterStyle('blue', null, array())
         );
-        $this->output->getFormatter()->setStyle(
+        $output->getFormatter()->setStyle(
             'dark', new OutputFormatterStyle('black', null, array('bold'))
         );
-    }
 
-    public function doGenerate(SuiteResult $suite, array $options)
-    {
         foreach ($suite->getBenchmarkResults() as $benchmark) {
             foreach ($benchmark->getSubjectResults() as $subject) {
-                $this->output->writeln(sprintf(
+                $output->writeln(sprintf(
                     '<comment>%s#%s()</comment>: %s',
                     $benchmark->getClass(),
                     $subject->getName(),
@@ -45,14 +42,14 @@ class ConsoleTableReportGenerator extends BaseTabularReportGenerator
                 ));
 
                 $data = $this->prepareData($subject, $options);
-                $this->renderData($data);
+                $this->renderData($output, $data);
 
-                $this->output->writeln('');
+                $output->writeln('');
             }
         }
     }
 
-    private function renderData($data)
+    private function renderData(OutputInterface $output, $data)
     {
         $data->map(function ($cell) {
             return number_format($cell->value(), 2);
@@ -83,7 +80,7 @@ class ConsoleTableReportGenerator extends BaseTabularReportGenerator
             return sprintf('<total>%s</total>', $cell->value());
         }, array('footer'));
 
-        $table = new Table($this->output);
+        $table = new Table($output);
 
         $table->setHeaders($data->getColumnNames());
         foreach ($data->getRows(array('spacer')) as $spacer) {

--- a/lib/ReportGenerator/ConsoleTableReportGenerator.php
+++ b/lib/ReportGenerator/ConsoleTableReportGenerator.php
@@ -14,7 +14,6 @@ namespace PhpBench\ReportGenerator;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\OutputInterface;
 use PhpBench\Result\SuiteResult;
-use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 
 class ConsoleTableReportGenerator extends BaseTabularReportGenerator
@@ -67,6 +66,7 @@ class ConsoleTableReportGenerator extends BaseTabularReportGenerator
         // format the memory
         $data->map(function ($cell) {
             $value = $cell->value();
+
             return number_format($cell->value()) . '<dark>b</dark>';
         }, array('memory'));
 
@@ -92,5 +92,5 @@ class ConsoleTableReportGenerator extends BaseTabularReportGenerator
         }
 
         $table->render();
-   }
+    }
 }

--- a/lib/ReportGenerator/OutputAwareReport.php
+++ b/lib/ReportGenerator/OutputAwareReport.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PhpBench\ReportGenerator;
+
+interface OutputAwareReport
+{
+    public function setOutput(OutputInterface $output);
+}

--- a/lib/ReportGenerator/OutputAwareReport.php
+++ b/lib/ReportGenerator/OutputAwareReport.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace PhpBench\ReportGenerator;
-
-interface OutputAwareReport
-{
-    public function setOutput(OutputInterface $output);
-}

--- a/lib/ReportGenerator/XmlTableReportGenerator.php
+++ b/lib/ReportGenerator/XmlTableReportGenerator.php
@@ -18,13 +18,6 @@ use PhpBench\PhpBench;
 
 class XmlTableReportGenerator extends BaseTabularReportGenerator
 {
-    private $output;
-
-    public function __construct(OutputInterface $output)
-    {
-        $this->output = $output;
-    }
-
     public function configure(OptionsResolver $options)
     {
         parent::configure($options);
@@ -35,7 +28,7 @@ class XmlTableReportGenerator extends BaseTabularReportGenerator
         ));
     }
 
-    public function doGenerate(SuiteResult $suite, array $options)
+    public function doGenerate(SuiteResult $suite, OutputInterface $output, array $options)
     {
         $dom = new \DOMDocument('1.0');
         $rootEl = $dom->createElement('bench');
@@ -69,7 +62,7 @@ class XmlTableReportGenerator extends BaseTabularReportGenerator
             }
         }
 
-        $this->output->writeln(sprintf('<info>Writing XML file to</info>: %s', $outfile));
+        $output->writeln(sprintf('<info>Writing XML file to</info>: %s', $outfile));
         file_put_contents($outfile, $dom->saveXml());
 
         if ($options['stdout']) {

--- a/tests/Functional/Bin/BinTest.php
+++ b/tests/Functional/Bin/BinTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace PhpBench\Tests\Functional\Bin;
+
+class BinTest extends \PHPUnit_Framework_TestCase
+{
+    private function execCommand($env, $command)
+    {
+        chdir(__DIR__ . '/' . $env);
+        $command = __DIR__ . '/../../../bin/phpbench ' . $command;
+        exec($command, $result, $status);
+
+        return array($status, implode($result, PHP_EOL));
+    }
+
+    /**
+     * It should use a speified, valid,  configuration
+     */
+    public function testSpecifiedConfig()
+    {
+        list($exitCode, $results) = $this->execCommand('.', 'run --config=env/config_valid/.phpbench');
+        $this->assertEquals(0, $exitCode);
+        $this->assertContains('Done', $results);
+    }
+
+    /**
+     * It should use .phpbench if present
+     * It should prioritize .phpbench over .phpbench.dist
+     */
+    public function testPhpBenchConfig()
+    {
+        list($exitCode, $results) = $this->execCommand('env/config_valid', 'run');
+        $this->assertEquals(0, $exitCode);
+        $this->assertContains('Done', $results);
+    }
+
+    /**
+     * It should use .phpbench.dist if present
+     */
+    public function testPhpBenchDistConfig()
+    {
+        list($exitCode, $results) = $this->execCommand('env/config_dist', 'run');
+        $this->assertEquals(0, $exitCode);
+        $this->assertContains('Done', $results);
+    }
+
+    /**
+     * It should exit with an error status if no configuration is present and no autoload is available
+     */
+    public function testNoAutoload()
+    {
+        list($exitCode, $results) = $this->execCommand('.', 'run');
+        $this->assertEquals(1, $exitCode);
+        $this->assertContains('does not exist', $results);
+    }
+
+    /**
+     * It should exist with an error status if the config file did not return a configuration object
+     */
+    public function testConfigNoReturnConfiguration()
+    {
+        list($exitCode, $results) = $this->execCommand('env/config_no_configuration', 'run');
+        $this->assertEquals(1, $exitCode);
+        $this->assertContains('did not return', $results);
+    }
+}

--- a/tests/Functional/Bin/BinTest.php
+++ b/tests/Functional/Bin/BinTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the PHP Bench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace PhpBench\Tests\Functional\Bin;
 
 class BinTest extends \PHPUnit_Framework_TestCase
@@ -14,7 +23,7 @@ class BinTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should use a speified, valid,  configuration
+     * It should use a speified, valid,  configuration.
      */
     public function testSpecifiedConfig()
     {
@@ -25,7 +34,7 @@ class BinTest extends \PHPUnit_Framework_TestCase
 
     /**
      * It should use .phpbench if present
-     * It should prioritize .phpbench over .phpbench.dist
+     * It should prioritize .phpbench over .phpbench.dist.
      */
     public function testPhpBenchConfig()
     {
@@ -35,7 +44,7 @@ class BinTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should use .phpbench.dist if present
+     * It should use .phpbench.dist if present.
      */
     public function testPhpBenchDistConfig()
     {
@@ -45,7 +54,7 @@ class BinTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should exit with an error status if no configuration is present and no autoload is available
+     * It should exit with an error status if no configuration is present and no autoload is available.
      */
     public function testNoAutoload()
     {
@@ -55,7 +64,7 @@ class BinTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should exist with an error status if the config file did not return a configuration object
+     * It should exist with an error status if the config file did not return a configuration object.
      */
     public function testConfigNoReturnConfiguration()
     {

--- a/tests/Functional/Bin/BinTest.php
+++ b/tests/Functional/Bin/BinTest.php
@@ -13,15 +13,6 @@ namespace PhpBench\Tests\Functional\Bin;
 
 class BinTest extends \PHPUnit_Framework_TestCase
 {
-    private function execCommand($env, $command)
-    {
-        chdir(__DIR__ . '/' . $env);
-        $command = __DIR__ . '/../../../bin/phpbench ' . $command;
-        exec($command, $result, $status);
-
-        return array($status, implode($result, PHP_EOL));
-    }
-
     /**
      * It should use a speified, valid,  configuration.
      */
@@ -71,5 +62,14 @@ class BinTest extends \PHPUnit_Framework_TestCase
         list($exitCode, $results) = $this->execCommand('env/config_no_configuration', 'run');
         $this->assertEquals(1, $exitCode);
         $this->assertContains('did not return', $results);
+    }
+
+    private function execCommand($env, $command)
+    {
+        chdir(__DIR__ . '/' . $env);
+        $command = __DIR__ . '/../../../bin/phpbench ' . $command;
+        exec($command, $result, $status);
+
+        return array($status, implode($result, PHP_EOL));
     }
 }

--- a/tests/Functional/Bin/env/config_dist/.phpbench.dist
+++ b/tests/Functional/Bin/env/config_dist/.phpbench.dist
@@ -1,0 +1,3 @@
+<?php
+
+return require_once(__DIR__ . '/../config_valid/.phpbench');

--- a/tests/Functional/Bin/env/config_valid/.phpbench
+++ b/tests/Functional/Bin/env/config_valid/.phpbench
@@ -1,0 +1,8 @@
+<?php
+
+require_once(__DIR__ . '/../../../../../vendor/autoload.php');
+
+$configuration = new PhpBench\Benchmark\Configuration();
+$configuration->setPath(__DIR__ . '/../../../benchmarks');
+
+return $configuration;

--- a/tests/Functional/Bin/env/config_valid/.phpbench
+++ b/tests/Functional/Bin/env/config_valid/.phpbench
@@ -2,7 +2,7 @@
 
 require_once(__DIR__ . '/../../../../../vendor/autoload.php');
 
-$configuration = new PhpBench\Benchmark\Configuration();
+$configuration = new PhpBench\Configuration();
 $configuration->setPath(__DIR__ . '/../../../benchmarks');
 
 return $configuration;

--- a/tests/Functional/Bin/env/config_valid/.phpbench.dist
+++ b/tests/Functional/Bin/env/config_valid/.phpbench.dist
@@ -1,0 +1,3 @@
+<?php
+
+throw new \Exception('This dist file should not be executed');

--- a/tests/Functional/Console/Command/RunCommandTest.php
+++ b/tests/Functional/Console/Command/RunCommandTest.php
@@ -22,6 +22,7 @@ class RunCommandTest extends BaseCommandTestCase
     public function testCommand()
     {
         $tester = $this->runCommand('run', array(
+            'path' => __DIR__ . '/../../benchmarks',
         ));
         $this->assertEquals(0, $tester->getStatusCode());
         $display = $tester->getDisplay();
@@ -34,6 +35,7 @@ class RunCommandTest extends BaseCommandTestCase
     public function testCommandWithReport()
     {
         $tester = $this->runCommand('run', array(
+            'path' => __DIR__ . '/../../benchmarks',
             '--report' => array('console_table'),
         ));
         $this->assertEquals(0, $tester->getStatusCode());
@@ -42,11 +44,25 @@ class RunCommandTest extends BaseCommandTestCase
     }
 
     /**
+     * It should throw an exception if no path is given (and no path is configured)
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage You must
+     */
+    public function testCommandWithNoPath()
+    {
+        $this->runCommand('run', array(
+            '--report' => array('console_table'),
+        ));
+    }
+
+    /**
      * It should run and generate a report configuration.
      */
     public function testCommandWithReportConfiguration()
     {
         $tester = $this->runCommand('run', array(
+            'path' => __DIR__ . '/../../benchmarks',
             '--report' => array('{"name": "console_table"}'),
         ));
         $this->assertEquals(0, $tester->getStatusCode());
@@ -64,6 +80,7 @@ class RunCommandTest extends BaseCommandTestCase
     {
         $tester = $this->runCommand('run', array(
             '--report' => array('{"name": "foo_console_table"}'),
+            'path' => __DIR__ . '/../../benchmarks',
         ));
         $this->assertEquals(0, $tester->getStatusCode());
         $display = $tester->getDisplay();
@@ -80,6 +97,7 @@ class RunCommandTest extends BaseCommandTestCase
     {
         $tester = $this->runCommand('run', array(
             '--report' => array('{"name": "foo_console_ta'),
+            'path' => __DIR__ . '/../../benchmarks',
         ));
         $this->assertEquals(0, $tester->getStatusCode());
         $display = $tester->getDisplay();
@@ -93,19 +111,11 @@ class RunCommandTest extends BaseCommandTestCase
     {
         $tester = $this->runCommand('run', array(
             '--dumpfile' => self::TEST_FNAME,
+            'path' => __DIR__ . '/../../benchmarks',
         ));
         $this->assertEquals(0, $tester->getStatusCode());
         $display = $tester->getDisplay();
         $this->assertContains('Dumped', $display);
         $this->assertTrue(file_exists(self::TEST_FNAME));
-    }
-
-    protected function runCommand($commandName, array $arguments)
-    {
-        $arguments = array_merge(array(
-            'path' => __DIR__ . '/../../benchmarks',
-        ), $arguments);
-
-        return parent::runCommand($commandName, $arguments);
     }
 }

--- a/tests/Functional/ReportGenerator/BaseReportGeneratorCase.php
+++ b/tests/Functional/ReportGenerator/BaseReportGeneratorCase.php
@@ -17,6 +17,7 @@ use PhpBench\Benchmark\SubjectBuilder;
 use PhpBench\Benchmark\Runner;
 use PhpBench\Benchmark\CollectionBuilder;
 use PhpBench\Result\SuiteResult;
+use Symfony\Component\Console\Output\NullOutput;
 
 abstract class BaseReportGeneratorCase extends \PHPUnit_Framework_TestCase
 {
@@ -42,6 +43,7 @@ abstract class BaseReportGeneratorCase extends \PHPUnit_Framework_TestCase
         $report = $this->getReport();
         $report->configure($resolver);
         $options = $resolver->resolve($options);
-        $report->generate($results, $options);
+        $output = new NullOutput();
+        $report->generate($results, $output, $options);
     }
 }

--- a/tests/Functional/ReportGenerator/BaseTabularReportGeneratorCase.php
+++ b/tests/Functional/ReportGenerator/BaseTabularReportGeneratorCase.php
@@ -42,12 +42,12 @@ abstract class BaseTabularReportGeneratorCase extends BaseReportGeneratorCase
     }
 
     /**
-     * It should allow revolutions
+     * It should allow revolutions.
      */
     public function testWithRevolutions()
     {
         $this->executeReport($this->getResults(), array(
-            'revolutions' => true
+            'revolutions' => true,
         ));
     }
 

--- a/tests/Functional/ReportGenerator/ConsoleReportGeneratorTest.php
+++ b/tests/Functional/ReportGenerator/ConsoleReportGeneratorTest.php
@@ -18,8 +18,6 @@ class ConsoleReportGeneratorTest extends BaseTabularReportGeneratorCase
 {
     public function getReport()
     {
-        $output = new NullOutput();
-
-        return new ConsoleTableReportGenerator($output);
+        return new ConsoleTableReportGenerator();
     }
 }

--- a/tests/Functional/ReportGenerator/ConsoleReportGeneratorTest.php
+++ b/tests/Functional/ReportGenerator/ConsoleReportGeneratorTest.php
@@ -12,7 +12,6 @@
 namespace PhpBench\Tests\Functional\ReportGenerator;
 
 use PhpBench\ReportGenerator\ConsoleTableReportGenerator;
-use Symfony\Component\Console\Output\NullOutput;
 
 class ConsoleReportGeneratorTest extends BaseTabularReportGeneratorCase
 {

--- a/tests/Functional/ReportGenerator/XmlReportGeneratorTest.php
+++ b/tests/Functional/ReportGenerator/XmlReportGeneratorTest.php
@@ -11,7 +11,6 @@
 
 namespace PhpBench\Tests\Functional\ReportGenerator;
 
-use Symfony\Component\Console\Output\NullOutput;
 use PhpBench\ReportGenerator\XmlTableReportGenerator;
 
 class XmlReportGeneratorTest extends BaseTabularReportGeneratorCase

--- a/tests/Functional/ReportGenerator/XmlReportGeneratorTest.php
+++ b/tests/Functional/ReportGenerator/XmlReportGeneratorTest.php
@@ -18,8 +18,6 @@ class XmlReportGeneratorTest extends BaseTabularReportGeneratorCase
 {
     public function getReport()
     {
-        $output = new NullOutput();
-
-        return new XmlTableReportGenerator($output);
+        return new XmlTableReportGenerator();
     }
 }

--- a/tests/Unit/Benchmark/CollectionBuilderTest.php
+++ b/tests/Unit/Benchmark/CollectionBuilderTest.php
@@ -25,7 +25,7 @@ class CollectionBuilderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * It should return a collection of all found bench cases.
-     * It should not instantiate abstract classes
+     * It should not instantiate abstract classes.
      */
     public function testBuildCollection()
     {

--- a/tests/Unit/Benchmark/findertest/AbstractBench.php
+++ b/tests/Unit/Benchmark/findertest/AbstractBench.php
@@ -9,10 +9,8 @@
  * file that was distributed with this source code.
  */
 
-use PhpBench\BenchIteration;
 use PhpBench\Benchmark;
 
 abstract class AbstractBench implements Benchmark
 {
 }
-

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace PhpBench\Tests\Unit;
+
+use PhpBench\Configuration;
+
+class ConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    private $configuration;
+
+    public function setUp()
+    {
+        $this->configuration = new Configuration();
+    }
+
+    /**
+     * It can have report generators added to it
+     */
+    public function testAddReportGenerator()
+    {
+        $generator = $this->prophesize('PhpBench\ReportGenerator');
+        $this->configuration->addReportGenerator('name', $generator->reveal());
+        $this->assertSame(array('name' => $generator->reveal()), $this->configuration->getReportGenerators());
+    }
+
+    /**
+     * It can have the path set on it
+     */
+    public function testSetPath()
+    {
+        $this->configuration->setPath('/foo');
+        $this->assertEquals('/foo', $this->configuration->getPath());
+    }
+
+    /**
+     * It can have report (configurations) added to it
+     */
+    public function testAddReport()
+    {
+        $this->configuration->addReport(array(
+            'name' => 'report',
+            'foo' => 'bar',
+        ));
+        $reports = $this->configuration->getReports();
+
+        $this->assertEquals(array(
+            array(
+            'name' => 'report',
+            'foo' => 'bar',
+        )), $reports);
+
+        return $this->configuration;
+    }
+
+    /**
+     * It can have the report (configurations) set/replaced
+     *
+     * @depends testAddReport
+     */
+    public function testSetReport(Configuration $configuration)
+    {
+        $this->assertCount(1, $configuration->getReports());
+        $configuration->setReports(array());
+        $this->assertCount(0, $configuration->getReports());
+    }
+}

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the PHP Bench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace PhpBench\Tests\Unit;
 
 use PhpBench\Configuration;
@@ -14,7 +23,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It can have report generators added to it
+     * It can have report generators added to it.
      */
     public function testAddReportGenerator()
     {
@@ -24,7 +33,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It can have the path set on it
+     * It can have the path set on it.
      */
     public function testSetPath()
     {
@@ -33,7 +42,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It can have report (configurations) added to it
+     * It can have report (configurations) added to it.
      */
     public function testAddReport()
     {
@@ -47,13 +56,13 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             array(
             'name' => 'report',
             'foo' => 'bar',
-        )), $reports);
+        ), ), $reports);
 
         return $this->configuration;
     }
 
     /**
-     * It can have the report (configurations) set/replaced
+     * It can have the report (configurations) set/replaced.
      *
      * @depends testAddReport
      */


### PR DESCRIPTION
The configuration class allows hte user to define default settings in the `.phpbench` or `.phpbench.dist` file , or a configuration file specified with the `--config` option.

The configuration file is a plain PHP file and must instantiate the `Configuration` class and bootstrap any autoloading required. (if no configuration is present `vendor/autoload.php` will be used).

It is possible for the user to add their own `ReportGenerator` instances, and eventually `ProgressLogger` instances if required.