### PR TITLE
Allow choice of showing in time in fraction of second in in microseconds

### DIFF
--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -23,6 +23,8 @@ use PhpBench\Exception\InvalidArgumentException;
 
 class Runner
 {
+    const MILLION = 1000000;
+
     private $logger;
     private $finder;
     private $subjectBuilder;
@@ -146,7 +148,7 @@ class Runner
         $memoryDiffInclusive = $endMemory - $this->subjectLastMemoryInclusive;
         $this->subjectLastMemoryInclusive = $endMemory;
 
-        $statistics['time'] = $end - $start;
+        $statistics['time'] = ($end * self::MILLION) - ($start * self::MILLION);
         $statistics['memory'] = $this->subjectMemoryTotal;
         $statistics['memory_diff'] = $memoryDiff;
         $statistics['memory_inc'] = $endMemory;

--- a/lib/ReportGenerator/BaseTabularReportGenerator.php
+++ b/lib/ReportGenerator/BaseTabularReportGenerator.php
@@ -24,7 +24,8 @@ abstract class BaseTabularReportGenerator implements ReportGenerator
     {
         $options->setDefaults(array(
             'aggregate_iterations' => false,
-            'precision' => 8,
+            'precision' => 6,
+            'time_format' => 'fraction',
             'time' => true,
             'memory' => false,
             'memory_inc' => false,
@@ -36,6 +37,7 @@ abstract class BaseTabularReportGenerator implements ReportGenerator
             'footer_max' => false,
         ));
 
+        $options->setAllowedValues('time_format', array('integer', 'fraction'));
         $options->setAllowedTypes('aggregate_iterations', 'bool');
         $options->setAllowedTypes('precision', 'int');
     }
@@ -53,7 +55,7 @@ abstract class BaseTabularReportGenerator implements ReportGenerator
         $cols = array();
 
         if ($options['time']) {
-            $cols['time'] = array('float');
+            $cols['time'] = array('time');
         }
 
         if ($options['memory']) {

--- a/lib/ReportGenerator/ConsoleTableReportGenerator.php
+++ b/lib/ReportGenerator/ConsoleTableReportGenerator.php
@@ -41,27 +41,40 @@ class ConsoleTableReportGenerator extends BaseTabularReportGenerator
                 ));
 
                 $data = $this->prepareData($subject, $options);
-                $this->renderData($output, $data);
+                $this->renderData($output, $data, $options);
 
                 $output->writeln('');
             }
         }
     }
 
-    private function renderData(OutputInterface $output, $data)
+    private function renderData(OutputInterface $output, $data, $options)
     {
         $data->map(function ($cell) {
             return number_format($cell->value(), 2);
         }, array('revs'));
 
-        // format the float cells
-        $data->map(function ($cell) {
-            $value = $cell->value();
-            $value =  number_format($value, $this->precision);
-            $value = preg_replace('{^([0|\\.]+)(.+)$}', '<blue>\1</blue>\2', $value);
 
-            return $value . '<dark>s</dark>';
-        }, array('float'));
+        switch ($options['time_format']) {
+            case 'integer':
+                // format the float cells
+                $data->map(function ($cell) {
+                    $value = $cell->value();
+                    $value =  number_format($value);
+
+                    return $value . '<dark>μs</dark>';
+                }, array('time'));
+                break;
+            default:
+                // format the float cells
+                $data->map(function ($cell) {
+                    $value = $cell->value();
+                    $value =  number_format($value / 1000000, $this->precision);
+                    $value = preg_replace('{^([0|\\.]+)(.+)$}', '<blue>\1</blue>\2', $value);
+
+                    return $value . '<dark>s</dark>';
+                }, array('time'));
+        }
 
         // format the memory
         $data->map(function ($cell) {

--- a/tests/Functional/ReportGenerator/BaseTabularReportGeneratorCase.php
+++ b/tests/Functional/ReportGenerator/BaseTabularReportGeneratorCase.php
@@ -70,4 +70,24 @@ abstract class BaseTabularReportGeneratorCase extends BaseReportGeneratorCase
             'memory_inc' => true,
         ));
     }
+
+    /**
+     * It should display time as a fraction of a second
+     */
+    public function testWithTimeFraction()
+    {
+        $this->executeReport($this->getResults(), array(
+            'time_format' => 'fraction',
+        ));
+    }
+
+    /**
+     * It should display time as the number of microseconds
+     */
+    public function testWithTimeInteger()
+    {
+        $this->executeReport($this->getResults(), array(
+            'time_format' => 'integer',
+        ));
+    }
 }


### PR DESCRIPTION
Show time either as a fraction of a second (`0.000032`) or as an integer representing microseconds (`32`)