### PR TITLE
Process Isolation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,6 @@ php:
 before_script:
   - composer install
 
-script: phpunit
+script: 
+  - phpunit
+  - php bin/phpbench run tests/Functional/benchmarks --report=console_table

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 5.7
 
 before_script:
   - composer install
+  - echo 'date.timezone = "Europe/Vienna"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 script: phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,5 @@ php:
 
 before_script:
   - composer install
-  - echo 'date.timezone = "Europe/Vienna"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 script: phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ before_script:
 
 script: 
   - phpunit
-  - php bin/phpbench run tests/Functional/benchmarks --config=tests/phpbench --dump
+  - php bin/phpbench run tests/Functional/benchmarks --config=tests/phpbench --dumpfile=dump.xml
+  - cat dump.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ before_script:
 
 script: 
   - phpunit
-  - php bin/phpbench run tests/Functional/benchmarks --config=tests/.phpbench
+  - php bin/phpbench run tests/Functional/benchmarks --config=tests/phpbench --dump

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - 5.7
 
 before_script:
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ before_script:
 
 script: 
   - phpunit
-  - php bin/phpbench run tests/Functional/benchmarks --report=console_table
+  - php bin/phpbench run tests/Functional/benchmarks --config=tests/.phpbench

--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ Specify a method which will provide parameters which can be accessed from the
 If multiple parameter providers are specified, then the they will be combined
 in to a cartesian product.
 
+### @processIsolation
+
+Run each iteration or each set of iterations in an isolated process. This is
+useful for seeing the initial cost of the revolution.
+
+Must be one of `iteration` or `iterations`.
+
 Installation
 ------------
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ class BenchmarkCase implements Benchmark
     }
 
     /**
+     * @description Each iteration will be in an isolated process
+     * @processIsolation iteration
+     */
+    public function benchSomethingIsolated()
+
+    /**
      * @paramProvider provideParamsOne
      * @paramProvider provideParamsTwo
      * @description Parameterized bench mark

--- a/lib/Benchmark/Parser.php
+++ b/lib/Benchmark/Parser.php
@@ -25,6 +25,7 @@ class Parser
             'paramProvider' => array(),
             'iterations' => array(),
             'description' => array(),
+            'processIsolation' => array(),
         );
 
         foreach ($lines as $line) {
@@ -57,9 +58,20 @@ class Parser
             );
         }
 
+        if (count($meta['processIsolation']) > 1) {
+            throw new InvalidArgumentException(
+                'Cannot specify more than one process isolation policy'
+            );
+        }
+
         $meta['description'] = reset($meta['description']);
+        $meta['processIsolation'] = reset($meta['processIsolation']);
         $iterations = $meta['iterations'];
         $meta['iterations'] = empty($iterations) ? 1 : (int) reset($iterations);
+
+        if ($meta['processIsolation']) {
+            Runner::validateProcessIsolation($meta['processIsolation']);
+        }
 
         return $meta;
     }

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -212,7 +212,6 @@ class Runner
             fclose($pipes[2]);
             $exitCode = proc_close($process);
 
-            // randomly returns -1 on travis ..
             if (0 !== $exitCode) {
                 throw new \RuntimeException(sprintf(
                     'Isolated process returned exit code "%s". Command: "%s". stdout: %s stderr: %s',

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -215,7 +215,7 @@ class Runner
             // randomly returns -1 on travis ..
             if (0 !== $exitCode) {
                 throw new \RuntimeException(sprintf(
-                    'Isolated process returned exit code "%s". Command: "%s". StdOut: %snStdErr: %s',
+                    'Isolated process returned exit code "%s". Command: "%s". stdout: %s stderr: %s',
                     $exitCode,
                     $command,
                     $output,

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -40,12 +40,11 @@ class Runner
     /**
      * @param CollectionBuilder $finder
      * @param SubjectBuilder $subjectBuilder
-     * @param ProgressLogger $logger 
-     *
+     * @param ProgressLogger $logger
      * @param mixed $processIsolation ProcessIsolation override
      * @param mixed $setUpTearDown Enable or disable setUp and tearDown
      * @param mixed $parameterOverride Ovreride the parameters
-     * @param mixed $iterationsOverride Override the number of iterations 
+     * @param mixed $iterationsOverride Override the number of iterations
      * @param mixed $configFile Isolated proceses need to know about the config
      */
     public function __construct(
@@ -153,6 +152,7 @@ class Runner
             $iteration = new Iteration($index, $parameters);
             $iterationResults[] = $this->runIteration($benchmark, $subject, $iteration);
         }
+
         return new IterationsResult($iterationResults, $parameters);
     }
 
@@ -171,8 +171,9 @@ class Runner
                 break;
             default:
                 throw new \RuntimeException(sprintf(
-                    'Invalid process islation policy "%s". This really should not happen.'
-                , $processIsolation));
+                    'Invalid process islation policy "%s". This really should not happen.',
+                    $processIsolation
+                ));
         }
 
         $iterationsResult = array();

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -179,11 +179,11 @@ class Runner
 
         for ($index = 0; $index < $iterationCount; $index++) {
             $command = sprintf(
-                '%s run %s --subject=%s --nosetup --dump --parameters=\'%s\' --iterations=%d --processisolation=none',
+                '%s run %s --subject=%s --nosetup --dump --parameters=%s --iterations=%d --processisolation=none',
                 $bin,
                 $reflection->getFileName(),
                 $subject->getMethodName(),
-                json_encode($parameters),
+                escapeshellarg(json_encode($parameters)),
                 $nbIterations
             );
 

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -41,7 +41,7 @@ class Runner
         $this->subjectBuilder = $subjectBuilder;
     }
 
-    public function runAll()
+    public function runAll($noSetup = false)
     {
         $collection = $this->finder->buildCollection();
 
@@ -49,7 +49,7 @@ class Runner
 
         foreach ($collection->getBenchmarks() as $benchmark) {
             $this->logger->benchmarkStart($benchmark);
-            $benchmarkResults[] = $this->run($benchmark);
+            $benchmarkResults[] = $this->run($benchmark, $noSetup);
             $this->logger->benchmarkEnd($benchmark);
         }
 
@@ -58,9 +58,9 @@ class Runner
         return $benchmarkSuiteResult;
     }
 
-    private function run(Benchmark $benchmark)
+    private function run(Benchmark $benchmark, $noSetup)
     {
-        if (method_exists($benchmark, 'setUp')) {
+        if (false === $noSetup && method_exists($benchmark, 'setUp')) {
             $benchmark->setUp();
         }
 
@@ -73,7 +73,7 @@ class Runner
             $this->logger->subjectEnd($subject);
         }
 
-        if (method_exists($benchmark, 'tearDown')) {
+        if (false === $noSetup && method_exists($benchmark, 'tearDown')) {
             $benchmark->tearDown();
         }
 

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -209,13 +209,13 @@ class Runner
             fclose($pipes[1]);
             $stderr = stream_get_contents($pipes[2]);
             fclose($pipes[2]);
-            $status = proc_get_status($process);
+            $exitCode = proc_close($process);
 
             // randomly returns -1 on travis ..
-            if ($status['exitcode'] > 0) {
+            if (0 !== $exitCode) {
                 throw new \RuntimeException(sprintf(
                     'Isolated process returned exit code "%s". Command: "%s". StdOut: %snStdErr: %s',
-                    $status['exitcode'],
+                    $exitCode,
                     $command,
                     $output,
                     $stderr

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -138,7 +138,7 @@ class Runner
 
         $bin = realpath(__DIR__ . '/../..') . '/bin/phpbench';
         $command = sprintf(
-            '%s run %s --subject=%s --dump --parameters=\'%s\'',
+            '%s run %s --subject=%s --nosetup --dump --parameters=\'%s\'',
             $bin,
             $reflection->getFileName(),
             $subject->getMethodName(),

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -205,6 +205,15 @@ class Runner
             }
 
             $output = stream_get_contents($pipes[1]);
+            $status = proc_get_status($process);
+
+            if (0 !== $status['exitcode']) {
+                throw new \RuntimeException(sprintf(
+                    'Failed to execute: "%s": %s',
+                    $command,
+                    $output
+                ));
+            }
 
             $loader = new XmlLoader();
             $subSuiteResult = $loader->load($output);

--- a/lib/Benchmark/Subject.php
+++ b/lib/Benchmark/Subject.php
@@ -18,19 +18,22 @@ class Subject
     private $parameterProviders;
     private $nbIterations;
     private $description;
+    private $processIsolation;
 
     public function __construct(
         $methodName,
         $beforeMethods,
         $parameterProviders,
         $nbIterations,
-        $description
+        $description,
+        $processIsolation
     ) {
         $this->methodName = $methodName;
         $this->beforeMethods = $beforeMethods;
         $this->parameterProviders = $parameterProviders;
         $this->nbIterations = $nbIterations;
         $this->description = $description;
+        $this->processIsolation = $processIsolation;
     }
 
     public function getBeforeMethods()
@@ -57,4 +60,10 @@ class Subject
     {
         return $this->methodName;
     }
+
+    public function getProcessIsolation() 
+    {
+        return $this->processIsolation;
+    }
+    
 }

--- a/lib/Benchmark/Subject.php
+++ b/lib/Benchmark/Subject.php
@@ -61,9 +61,8 @@ class Subject
         return $this->methodName;
     }
 
-    public function getProcessIsolation() 
+    public function getProcessIsolation()
     {
         return $this->processIsolation;
     }
-    
 }

--- a/lib/Benchmark/SubjectBuilder.php
+++ b/lib/Benchmark/SubjectBuilder.php
@@ -46,7 +46,8 @@ class SubjectBuilder
                 $meta['beforeMethod'],
                 $meta['paramProvider'],
                 $meta['iterations'],
-                $meta['description']
+                $meta['description'],
+                $meta['processIsolation']
             );
         }
 

--- a/lib/Benchmark/SubjectBuilder.php
+++ b/lib/Benchmark/SubjectBuilder.php
@@ -16,12 +16,12 @@ use PhpBench\Benchmark;
 class SubjectBuilder
 {
     private $parser;
-    private $filter;
+    private $subject;
 
-    public function __construct($filter = null)
+    public function __construct($subject = null)
     {
         $this->parser = new Parser();
-        $this->filter = $filter;
+        $this->subject = $subject;
     }
 
     public function buildSubjects(Benchmark $case)
@@ -35,7 +35,7 @@ class SubjectBuilder
                 continue;
             }
 
-            if ($this->filter && !preg_match('{' . $this->filter . '}', $method->getName())) {
+            if ($this->subject && $method->getName() !== $this->subject) {
                 continue;
             }
 

--- a/lib/Console/Command/RunCommand.php
+++ b/lib/Console/Command/RunCommand.php
@@ -45,7 +45,7 @@ EOT
         $this->addOption('dumpfile', 'df', InputOption::VALUE_OPTIONAL, 'Dump XML result to named file');
         $this->addOption('dump', null, InputOption::VALUE_NONE, 'Dump XML result to stdout');
         $this->addOption('parameters', null, InputOption::VALUE_REQUIRED, 'Explicit parameters to use in benchmark');
-        $this->addOption('nosetup', null, InputOption::VALUE_REQUIRED, 'Do not execute setUp or tearDown methods');
+        $this->addOption('nosetup', null, InputOption::VALUE_NONE, 'Do not execute setUp or tearDown methods');
         $this->addOption('separateprocess', null, InputOption::VALUE_NONE, 'Run iterations in separate processes');
     }
 

--- a/lib/Console/Command/RunCommand.php
+++ b/lib/Console/Command/RunCommand.php
@@ -46,6 +46,7 @@ EOT
         $this->addOption('dump', null, InputOption::VALUE_NONE, 'Dump XML result to stdout');
         $this->addOption('parameters', null, InputOption::VALUE_REQUIRED, 'Explicit parameters to use in benchmark');
         $this->addOption('nosetup', null, InputOption::VALUE_REQUIRED, 'Do not execute setUp or tearDown methods');
+        $this->addOption('separateprocess', null, InputOption::VALUE_NONE, 'Run iterations in separate processes');
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
@@ -59,7 +60,7 @@ EOT
 
         if ($parametersJson) {
             $parameters = json_decode($parametersJson, true);
-            if (!$parameters) {
+            if (null === $parameters) {
                 throw new \InvalidArgumentException(sprintf(
                     'Could not decode parameters JSON string: "%s"', $parametersJson
                 ));
@@ -86,9 +87,10 @@ EOT
 
         $subject = $input->getOption('subject');
         $dumpfile = $input->getOption('dumpfile');
+        $separateProcess = $input->getOption('separateprocess');
 
         $startTime = microtime(true);
-        $result = $this->executeBenchmarks($consoleOutput, $path, $subject, $noSetup, $parameters);
+        $result = $this->executeBenchmarks($consoleOutput, $path, $subject, $noSetup, $parameters, $separateProcess);
 
         $consoleOutput->writeln('');
 
@@ -117,7 +119,7 @@ EOT
         return $dumper->dump($result);
     }
 
-    private function executeBenchmarks(OutputInterface $output, $path, $subject, $noSetup, $parameters)
+    private function executeBenchmarks(OutputInterface $output, $path, $subject, $noSetup, $parameters, $separateProcess)
     {
         $finder = new Finder();
 
@@ -142,7 +144,8 @@ EOT
         $benchRunner = new Runner(
             $benchFinder,
             $subjectBuilder,
-            $progressLogger
+            $progressLogger,
+            $separateProcess
         );
 
         return $benchRunner->runAll($noSetup, $parameters);

--- a/lib/Console/Command/RunCommand.php
+++ b/lib/Console/Command/RunCommand.php
@@ -145,9 +145,11 @@ EOT
             $benchFinder,
             $subjectBuilder,
             $progressLogger,
-            $separateProcess
+            $separateProcess,
+            !$noSetup,
+            $parameters
         );
 
-        return $benchRunner->runAll($noSetup, $parameters);
+        return $benchRunner->runAll();
     }
 }

--- a/lib/Console/Command/RunCommand.php
+++ b/lib/Console/Command/RunCommand.php
@@ -44,6 +44,7 @@ EOT
         $this->addOption('filter', null, InputOption::VALUE_REQUIRED, 'Filter subject(s) to run');
         $this->addOption('dumpfile', 'df', InputOption::VALUE_OPTIONAL, 'Dump XML result to named file');
         $this->addOption('dump', null, InputOption::VALUE_NONE, 'Dump XML result to stdout');
+        $this->addOption('nosetup', null, InputOption::VALUE_NONE, 'Do not execute setUp or tearDown methods');
     }
 
     public function execute(InputInterface $input, OutputInterface $output)

--- a/lib/Console/Command/RunCommand.php
+++ b/lib/Console/Command/RunCommand.php
@@ -44,7 +44,8 @@ EOT
         $this->addOption('subject', null, InputOption::VALUE_REQUIRED, 'Subject to run');
         $this->addOption('dumpfile', 'df', InputOption::VALUE_OPTIONAL, 'Dump XML result to named file');
         $this->addOption('dump', null, InputOption::VALUE_NONE, 'Dump XML result to stdout');
-        $this->addOption('parameters', null, InputOption::VALUE_REQUIRED, 'Explicit parameters to use in benchmark');
+        $this->addOption('parameters', null, InputOption::VALUE_REQUIRED, 'Override parameters to use in (all) benchmarks');
+        $this->addOption('iterations', null, InputOption::VALUE_REQUIRED, 'Override number of iteratios to run in (all) benchmarks');
         $this->addOption('nosetup', null, InputOption::VALUE_NONE, 'Do not execute setUp or tearDown methods');
         $this->addOption('separateprocess', null, InputOption::VALUE_NONE, 'Run iterations in separate processes');
     }
@@ -56,6 +57,7 @@ EOT
         $dump = $input->getOption('dump');
         $parametersJson = $input->getOption('parameters');
         $noSetup = $input->getOption('nosetup');
+        $iterations = $input->getOption('iterations');
         $parameters = null;
 
         if ($parametersJson) {
@@ -90,7 +92,7 @@ EOT
         $separateProcess = $input->getOption('separateprocess');
 
         $startTime = microtime(true);
-        $result = $this->executeBenchmarks($consoleOutput, $path, $subject, $noSetup, $parameters, $separateProcess);
+        $result = $this->executeBenchmarks($consoleOutput, $path, $subject, $noSetup, $parameters, $iterations, $separateProcess);
 
         $consoleOutput->writeln('');
 
@@ -119,7 +121,7 @@ EOT
         return $dumper->dump($result);
     }
 
-    private function executeBenchmarks(OutputInterface $output, $path, $subject, $noSetup, $parameters, $separateProcess)
+    private function executeBenchmarks(OutputInterface $output, $path, $subject, $noSetup, $parameters, $iterations, $separateProcess)
     {
         $finder = new Finder();
 
@@ -147,7 +149,8 @@ EOT
             $progressLogger,
             $separateProcess,
             !$noSetup,
-            $parameters
+            $parameters,
+            $iterations
         );
 
         return $benchRunner->runAll();

--- a/lib/Console/Command/RunCommand.php
+++ b/lib/Console/Command/RunCommand.php
@@ -59,7 +59,7 @@ EOT
         $noSetup = $input->getOption('nosetup');
         $iterations = $input->getOption('iterations');
         $configFile = $input->getOption('config');
-        $processIsolation = $input->getOption('processisolation') ? : null;
+        $processIsolation = $input->getOption('processisolation') ?: null;
         $processIsolation = $processIsolation === 'none' ? false : $processIsolation;
         $parameters = null;
 
@@ -121,6 +121,7 @@ EOT
     private function dumpResult(SuiteResult $result)
     {
         $dumper = new XmlDumper();
+
         return $dumper->dump($result);
     }
 

--- a/lib/ReportGenerator/BaseTabularReportGenerator.php
+++ b/lib/ReportGenerator/BaseTabularReportGenerator.php
@@ -82,7 +82,7 @@ abstract class BaseTabularReportGenerator implements ReportGenerator
                 }
 
                 if ($options['revolutions']) {
-                    $row->set('revs', $iteration->get('time') ? 1000000 / $iteration->get('time') : '∞', array('revs'));
+                    $row->set('revs', $iteration->get('time') ? 1000000 / $iteration->get('time') : null, array('revs'));
                 }
             }
         }

--- a/lib/ReportGenerator/BaseTabularReportGenerator.php
+++ b/lib/ReportGenerator/BaseTabularReportGenerator.php
@@ -82,7 +82,7 @@ abstract class BaseTabularReportGenerator implements ReportGenerator
                 }
 
                 if ($options['revolutions']) {
-                    $row->set('revs', 1000000 / $iteration->get('time'), array('revs'));
+                    $row->set('revs', $iteration->get('time') ? 1000000 / $iteration->get('time') : '∞', array('revs'));
                 }
             }
         }

--- a/lib/ReportGenerator/ConsoleTableReportGenerator.php
+++ b/lib/ReportGenerator/ConsoleTableReportGenerator.php
@@ -55,7 +55,7 @@ class ConsoleTableReportGenerator extends BaseTabularReportGenerator
         $precision = $this->precision;
 
         $data->map(function ($cell) {
-            return number_format($cell->value(), 2);
+            return null !== $cell->value() ? number_format($cell->value(), 2) : '∞';
         }, array('revs'));
 
 

--- a/lib/ReportGenerator/ConsoleTableReportGenerator.php
+++ b/lib/ReportGenerator/ConsoleTableReportGenerator.php
@@ -58,7 +58,6 @@ class ConsoleTableReportGenerator extends BaseTabularReportGenerator
             return null !== $cell->value() ? number_format($cell->value(), 2) : '∞';
         }, array('revs'));
 
-
         switch ($options['time_format']) {
             case 'integer':
                 // format the float cells

--- a/lib/Result/Dumper/XmlDumper.php
+++ b/lib/Result/Dumper/XmlDumper.php
@@ -26,9 +26,7 @@ class XmlDumper
         $dom->formatOutput = true;
         $rootEl = $dom->createElement('phpbench');
         $rootEl->setAttribute('version', PhpBench::VERSION);
-
-        // ignore timezone errors (travis)
-        $rootEl->setAttribute('date', @date('c'));
+        $rootEl->setAttribute('date', date('c'));
         $dom->appendChild($rootEl);
 
         $childEl = null;

--- a/lib/Result/Dumper/XmlDumper.php
+++ b/lib/Result/Dumper/XmlDumper.php
@@ -26,7 +26,9 @@ class XmlDumper
         $dom->formatOutput = true;
         $rootEl = $dom->createElement('phpbench');
         $rootEl->setAttribute('version', PhpBench::VERSION);
-        $rootEl->setAttribute('date', date('c'));
+
+        // ignore timezone errors (travis)
+        $rootEl->setAttribute('date', @date('c'));
         $dom->appendChild($rootEl);
 
         $childEl = null;

--- a/lib/Result/SuiteResult.php
+++ b/lib/Result/SuiteResult.php
@@ -24,4 +24,28 @@ class SuiteResult
     {
         return $this->benchmarkResults;
     }
+
+    public function getIterationsResults()
+    {
+        $iterationsResults = array();
+        foreach ($this->getSubjectResults() as $subjectResult) {
+            foreach ($subjectResult->getIterationsResults() as $iterationResult) {
+                $iterationsResults[] = $iterationResult;
+            }
+        }
+
+        return $iterationsResults;
+    }
+
+    public function getSubjectResults()
+    {
+        $subjectResults = array();
+        foreach ($this->benchmarkResults as $benchmarkResult) {
+            foreach ($benchmarkResult->getSubjectResults() as $subjectResult) {
+                $subjectResults[] = $subjectResult;
+            }
+        }
+
+        return $subjectResults;
+    }
 }

--- a/tests/Functional/Bin/BinTest.php
+++ b/tests/Functional/Bin/BinTest.php
@@ -55,7 +55,7 @@ class BinTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should exist with an error status if the config file did not return a configuration object.
+     * It should exit with an error status if the config file did not return a configuration object.
      */
     public function testConfigNoReturnConfiguration()
     {

--- a/tests/Functional/Console/Command/RunCommandTest.php
+++ b/tests/Functional/Console/Command/RunCommandTest.php
@@ -22,7 +22,7 @@ class RunCommandTest extends BaseCommandTestCase
     public function testCommand()
     {
         $tester = $this->runCommand('run', array(
-            'path' => __DIR__ . '/../../benchmarks',
+            'path' => __DIR__ . '/../../benchmarks/BenchmarkCase.php',
         ));
         $this->assertEquals(0, $tester->getStatusCode());
         $display = $tester->getDisplay();
@@ -35,7 +35,7 @@ class RunCommandTest extends BaseCommandTestCase
     public function testCommandWithReport()
     {
         $tester = $this->runCommand('run', array(
-            'path' => __DIR__ . '/../../benchmarks',
+            'path' => __DIR__ . '/../../benchmarks/BenchmarkCase.php',
             '--report' => array('console_table'),
         ));
         $this->assertEquals(0, $tester->getStatusCode());
@@ -62,7 +62,7 @@ class RunCommandTest extends BaseCommandTestCase
     public function testCommandWithReportConfiguration()
     {
         $tester = $this->runCommand('run', array(
-            'path' => __DIR__ . '/../../benchmarks',
+            'path' => __DIR__ . '/../../benchmarks/BenchmarkCase.php',
             '--report' => array('{"name": "console_table"}'),
         ));
         $this->assertEquals(0, $tester->getStatusCode());
@@ -80,7 +80,7 @@ class RunCommandTest extends BaseCommandTestCase
     {
         $tester = $this->runCommand('run', array(
             '--report' => array('{"name": "foo_console_table"}'),
-            'path' => __DIR__ . '/../../benchmarks',
+            'path' => __DIR__ . '/../../benchmarks/BenchmarkCase.php',
         ));
         $this->assertEquals(0, $tester->getStatusCode());
         $display = $tester->getDisplay();
@@ -97,7 +97,7 @@ class RunCommandTest extends BaseCommandTestCase
     {
         $tester = $this->runCommand('run', array(
             '--report' => array('{"name": "foo_console_ta'),
-            'path' => __DIR__ . '/../../benchmarks',
+            'path' => __DIR__ . '/../../benchmarks/BenchmarkCase.php',
         ));
         $this->assertEquals(0, $tester->getStatusCode());
         $display = $tester->getDisplay();
@@ -111,7 +111,7 @@ class RunCommandTest extends BaseCommandTestCase
     {
         $tester = $this->runCommand('run', array(
             '--dumpfile' => self::TEST_FNAME,
-            'path' => __DIR__ . '/../../benchmarks',
+            'path' => __DIR__ . '/../../benchmarks/BenchmarkCase.php',
         ));
         $this->assertEquals(0, $tester->getStatusCode());
         $display = $tester->getDisplay();
@@ -126,7 +126,7 @@ class RunCommandTest extends BaseCommandTestCase
     {
         $tester = $this->runCommand('run', array(
             '--dump' => true,
-            'path' => __DIR__ . '/../../benchmarks',
+            'path' => __DIR__ . '/../../benchmarks/BenchmarkCase.php',
         ));
         $this->assertEquals(0, $tester->getStatusCode());
         $display = $tester->getDisplay();
@@ -145,7 +145,7 @@ class RunCommandTest extends BaseCommandTestCase
         $tester = $this->runCommand('run', array(
             '--dump' => true,
             '--parameters' => '{"length": 333}',
-            'path' => __DIR__ . '/../../benchmarks',
+            'path' => __DIR__ . '/../../benchmarks/BenchmarkCase.php',
         ));
         $this->assertEquals(0, $tester->getStatusCode());
         $display = $tester->getDisplay();
@@ -166,7 +166,7 @@ class RunCommandTest extends BaseCommandTestCase
         $this->runCommand('run', array(
             '--dump' => true,
             '--parameters' => '{"length: 3,',
-            'path' => __DIR__ . '/../../benchmarks',
+            'path' => __DIR__ . '/../../benchmarks/BenchmarkCase.php',
         ));
     }
 
@@ -179,7 +179,7 @@ class RunCommandTest extends BaseCommandTestCase
             '--subject' => 'benchRandom',
             '--dump' => true,
             '--iterations' => 10,
-            'path' => __DIR__ . '/../../benchmarks',
+            'path' => __DIR__ . '/../../benchmarks/BenchmarkCase.php',
         ));
 
         $this->assertEquals(0, $tester->getStatusCode());
@@ -193,11 +193,25 @@ class RunCommandTest extends BaseCommandTestCase
     }
 
     /**
-     * It should run iterations in separate processes
+     * It can run each iteration in isolation
      */
-    public function testSeparateProcess()
+    public function testProcessIsolationIteration()
     {
-        $this->markTestIncomplete();
+        $tester = $this->runCommand('run', array(
+            '--processisolation' => 'iteration',
+            'path' => __DIR__ . '/../../benchmarks/BenchmarkCase.php',
+        ));
+    }
+
+    /**
+     * It can run each set of iterations in isolation
+     */
+    public function testProcessIsolationIterations()
+    {
+        $tester = $this->runCommand('run', array(
+            '--processisolation' => 'iterations',
+            'path' => __DIR__ . '/../../benchmarks/IsolatedCase.php',
+        ));
     }
 
     /**

--- a/tests/Functional/Console/Command/RunCommandTest.php
+++ b/tests/Functional/Console/Command/RunCommandTest.php
@@ -44,7 +44,7 @@ class RunCommandTest extends BaseCommandTestCase
     }
 
     /**
-     * It should throw an exception if no path is given (and no path is configured)
+     * It should throw an exception if no path is given (and no path is configured).
      *
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage You must
@@ -120,7 +120,7 @@ class RunCommandTest extends BaseCommandTestCase
     }
 
     /**
-     * It should dump to stdout
+     * It should dump to stdout.
      */
     public function testDumpXmlStdOut()
     {
@@ -138,7 +138,7 @@ class RunCommandTest extends BaseCommandTestCase
     }
 
     /**
-     * It should accept explicit parameters
+     * It should accept explicit parameters.
      */
     public function testOverrideParameters()
     {
@@ -157,7 +157,7 @@ class RunCommandTest extends BaseCommandTestCase
     }
 
     /**
-     * It should throw an exception if an invalid JSON string is provided for parameters
+     * It should throw an exception if an invalid JSON string is provided for parameters.
      *
      * @expectedException InvalidArgumentException
      */
@@ -171,7 +171,7 @@ class RunCommandTest extends BaseCommandTestCase
     }
 
     /**
-     * Its should allow the number of iterations to be specified
+     * Its should allow the number of iterations to be specified.
      */
     public function testOverrideIterations()
     {
@@ -193,7 +193,7 @@ class RunCommandTest extends BaseCommandTestCase
     }
 
     /**
-     * It can run each iteration in isolation
+     * It can run each iteration in isolation.
      */
     public function testProcessIsolationIteration()
     {
@@ -204,7 +204,7 @@ class RunCommandTest extends BaseCommandTestCase
     }
 
     /**
-     * It can run each set of iterations in isolation
+     * It can run each set of iterations in isolation.
      */
     public function testProcessIsolationIterations()
     {
@@ -215,7 +215,7 @@ class RunCommandTest extends BaseCommandTestCase
     }
 
     /**
-     * It should escape paramters when running in separate process
+     * It should escape paramters when running in separate process.
      */
     public function testSeparateProcessEscape()
     {

--- a/tests/Functional/Console/Command/RunCommandTest.php
+++ b/tests/Functional/Console/Command/RunCommandTest.php
@@ -118,4 +118,22 @@ class RunCommandTest extends BaseCommandTestCase
         $this->assertContains('Dumped', $display);
         $this->assertTrue(file_exists(self::TEST_FNAME));
     }
+
+    /**
+     * It should dump to stdout
+     */
+    public function testDumpXmlStdOut()
+    {
+        $tester = $this->runCommand('run', array(
+            '--dump' => true,
+            'path' => __DIR__ . '/../../benchmarks',
+        ));
+        $this->assertEquals(0, $tester->getStatusCode());
+        $display = $tester->getDisplay();
+        $dom = new \DOMDocument();
+        $dom->loadXml($display);
+        $xpath = new \DOMXPath($dom);
+        $benchmarkEls = $xpath->query('//subject');
+        $this->assertEquals(3, $benchmarkEls->length);
+    }
 }

--- a/tests/Functional/Console/Command/RunCommandTest.php
+++ b/tests/Functional/Console/Command/RunCommandTest.php
@@ -136,4 +136,37 @@ class RunCommandTest extends BaseCommandTestCase
         $benchmarkEls = $xpath->query('//subject');
         $this->assertEquals(3, $benchmarkEls->length);
     }
+
+    /**
+     * It should accept explicit parameters
+     */
+    public function testExplicitParameters()
+    {
+        $tester = $this->runCommand('run', array(
+            '--dump' => true,
+            '--parameters' => '{"length": 333}',
+            'path' => __DIR__ . '/../../benchmarks',
+        ));
+        $this->assertEquals(0, $tester->getStatusCode());
+        $display = $tester->getDisplay();
+        $dom = new \DOMDocument();
+        $dom->loadXml($display);
+        $xpath = new \DOMXPath($dom);
+        $parameters = $xpath->query('//parameter[@value=333]');
+        $this->assertEquals(3, $parameters->length);
+    }
+
+    /**
+     * It should throw an exception if an invalid JSON string is provided for parameters
+     *
+     * @expectedException InvalidArgumentException
+     */
+    public function testExplicitParametersInvalidJson()
+    {
+        $this->runCommand('run', array(
+            '--dump' => true,
+            '--parameters' => '{"length: 3,',
+            'path' => __DIR__ . '/../../benchmarks',
+        ));
+    }
 }

--- a/tests/Functional/Console/Command/RunCommandTest.php
+++ b/tests/Functional/Console/Command/RunCommandTest.php
@@ -197,7 +197,7 @@ class RunCommandTest extends BaseCommandTestCase
      */
     public function testProcessIsolationIteration()
     {
-        $tester = $this->runCommand('run', array(
+        $this->runCommand('run', array(
             '--processisolation' => 'iteration',
             'path' => __DIR__ . '/../../benchmarks/BenchmarkCase.php',
         ));
@@ -208,7 +208,7 @@ class RunCommandTest extends BaseCommandTestCase
      */
     public function testProcessIsolationIterations()
     {
-        $tester = $this->runCommand('run', array(
+        $this->runCommand('run', array(
             '--processisolation' => 'iterations',
             'path' => __DIR__ . '/../../benchmarks/IsolatedCase.php',
         ));
@@ -219,6 +219,9 @@ class RunCommandTest extends BaseCommandTestCase
      */
     public function testSeparateProcessEscape()
     {
-        $this->markTestIncomplete();
+        $this->runCommand('run', array(
+            '--processisolation' => 'iteration',
+            'path' => __DIR__ . '/../../benchmarks/IsolatedParametersCase.php',
+        ));
     }
 }

--- a/tests/Functional/Console/Command/RunCommandTest.php
+++ b/tests/Functional/Console/Command/RunCommandTest.php
@@ -16,6 +16,21 @@ use PhpBench\Tests\Functional\Console\Command\BaseCommandTestCase;
 
 class RunCommandTest extends BaseCommandTestCase
 {
+    private $pidPath;
+
+    public function setUp()
+    {
+        $this->pidPath = sys_get_temp_dir() . '/phpbench_isolationtest';
+        if (file_exists($this->pidPath)) {
+            unlink($this->pidPath);
+        }
+    }
+
+    public function tearDown()
+    {
+        $this->setUp();
+    }
+
     /**
      * It should run when given a path.
      */
@@ -194,17 +209,22 @@ class RunCommandTest extends BaseCommandTestCase
 
     /**
      * It can run each iteration in isolation.
+     * There are 2 subjects each with 5 iterations, so there should be 10 PIDs
      */
     public function testProcessIsolationIteration()
     {
         $this->runCommand('run', array(
             '--processisolation' => 'iteration',
-            'path' => __DIR__ . '/../../benchmarks/BenchmarkCase.php',
+            'path' => __DIR__ . '/../../benchmarks/IsolatedCase.php',
         ));
+
+        $pids = array_unique(explode(PHP_EOL, trim(file_get_contents($this->pidPath))));
+        $this->assertCount(10, $pids);
     }
 
     /**
      * It can run each set of iterations in isolation.
+     * There are 2 subjects, so there should be 2 PIDs
      */
     public function testProcessIsolationIterations()
     {
@@ -212,6 +232,9 @@ class RunCommandTest extends BaseCommandTestCase
             '--processisolation' => 'iterations',
             'path' => __DIR__ . '/../../benchmarks/IsolatedCase.php',
         ));
+
+        $pids = array_unique(explode(PHP_EOL, trim(file_get_contents($this->pidPath))));
+        $this->assertCount(2, $pids);
     }
 
     /**

--- a/tests/Functional/Console/Command/RunCommandTest.php
+++ b/tests/Functional/Console/Command/RunCommandTest.php
@@ -169,4 +169,20 @@ class RunCommandTest extends BaseCommandTestCase
             'path' => __DIR__ . '/../../benchmarks',
         ));
     }
+
+    /**
+     * It should run iterations in separate processes
+     */
+    public function testSeparateProcess()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /**
+     * It should escape paramters when running in separate process
+     */
+    public function testSeparateProcessEscape()
+    {
+        $this->markTestIncomplete();
+    }
 }

--- a/tests/Functional/Console/Command/RunCommandTest.php
+++ b/tests/Functional/Console/Command/RunCommandTest.php
@@ -140,7 +140,7 @@ class RunCommandTest extends BaseCommandTestCase
     /**
      * It should accept explicit parameters
      */
-    public function testExplicitParameters()
+    public function testOverrideParameters()
     {
         $tester = $this->runCommand('run', array(
             '--dump' => true,
@@ -161,13 +161,35 @@ class RunCommandTest extends BaseCommandTestCase
      *
      * @expectedException InvalidArgumentException
      */
-    public function testExplicitParametersInvalidJson()
+    public function testOverrideParametersInvalidJson()
     {
         $this->runCommand('run', array(
             '--dump' => true,
             '--parameters' => '{"length: 3,',
             'path' => __DIR__ . '/../../benchmarks',
         ));
+    }
+
+    /**
+     * Its should allow the number of iterations to be specified
+     */
+    public function testOverrideIterations()
+    {
+        $tester = $this->runCommand('run', array(
+            '--subject' => 'benchRandom',
+            '--dump' => true,
+            '--iterations' => 10,
+            'path' => __DIR__ . '/../../benchmarks',
+        ));
+
+        $this->assertEquals(0, $tester->getStatusCode());
+        $display = $tester->getDisplay();
+        $dom = new \DOMDocument();
+        $dom->loadXml($display);
+        $dom->formatOutput = true;
+        $xpath = new \DOMXPath($dom);
+        $parameters = $xpath->query('//iteration');
+        $this->assertEquals(10, $parameters->length);
     }
 
     /**

--- a/tests/Functional/ReportGenerator/BaseReportGeneratorCase.php
+++ b/tests/Functional/ReportGenerator/BaseReportGeneratorCase.php
@@ -18,23 +18,14 @@ use PhpBench\Benchmark\Runner;
 use PhpBench\Benchmark\CollectionBuilder;
 use PhpBench\Result\SuiteResult;
 use Symfony\Component\Console\Output\NullOutput;
+use PhpBench\Result\Loader\XmlLoader;
 
 abstract class BaseReportGeneratorCase extends \PHPUnit_Framework_TestCase
 {
     protected function getResults()
     {
-        $finder = new Finder();
-        $finder->in(__DIR__ . '/../benchmarks');
-
-        $benchFinder = new CollectionBuilder($finder);
-        $subjectBuilder = new SubjectBuilder();
-
-        $benchRunner = new Runner(
-            $benchFinder,
-            $subjectBuilder
-        );
-
-        return $benchRunner->runAll();
+        $xmlLoader = new XmlLoader();
+        return $xmlLoader->load(file_get_contents(__DIR__ . '/report.xml'));
     }
 
     protected function executeReport(SuiteResult $results, array $options)

--- a/tests/Functional/ReportGenerator/BaseTabularReportGeneratorCase.php
+++ b/tests/Functional/ReportGenerator/BaseTabularReportGeneratorCase.php
@@ -72,7 +72,7 @@ abstract class BaseTabularReportGeneratorCase extends BaseReportGeneratorCase
     }
 
     /**
-     * It should display time as a fraction of a second
+     * It should display time as a fraction of a second.
      */
     public function testWithTimeFraction()
     {
@@ -82,7 +82,7 @@ abstract class BaseTabularReportGeneratorCase extends BaseReportGeneratorCase
     }
 
     /**
-     * It should display time as the number of microseconds
+     * It should display time as the number of microseconds.
      */
     public function testWithTimeInteger()
     {

--- a/tests/Functional/ReportGenerator/report.xml
+++ b/tests/Functional/ReportGenerator/report.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0"?>
+<phpbench version="0.1" date="2015-05-24T09:38:53+02:00">
+  <suite>
+    <benchmark class="PhpBench\Tests\Functional\benchmarks\ArrayKeysCase">
+      <subject name="benchIsset" description="isset">
+        <iterations>
+          <iteration time="6" memory="216" memory_diff="216" memory_inc="2977288" memory_diff_inc="29368"/>
+          <iteration time="3" memory="360" memory_diff="144" memory_inc="2982640" memory_diff_inc="5352"/>
+          <iteration time="3" memory="504" memory_diff="144" memory_inc="2983752" memory_diff_inc="1112"/>
+          <iteration time="3" memory="648" memory_diff="144" memory_inc="2984864" memory_diff_inc="1112"/>
+          <iteration time="3" memory="792" memory_diff="144" memory_inc="2985976" memory_diff_inc="1112"/>
+          <iteration time="3" memory="936" memory_diff="144" memory_inc="2987088" memory_diff_inc="1112"/>
+          <iteration time="3" memory="1080" memory_diff="144" memory_inc="2988200" memory_diff_inc="1112"/>
+          <iteration time="3" memory="1224" memory_diff="144" memory_inc="2989312" memory_diff_inc="1112"/>
+          <iteration time="3" memory="1368" memory_diff="144" memory_inc="2990424" memory_diff_inc="1112"/>
+          <iteration time="3" memory="1512" memory_diff="144" memory_inc="2991600" memory_diff_inc="1176"/>
+          <iteration time="3" memory="1656" memory_diff="144" memory_inc="2992712" memory_diff_inc="1112"/>
+          <iteration time="3" memory="1800" memory_diff="144" memory_inc="2993824" memory_diff_inc="1112"/>
+          <iteration time="3" memory="1944" memory_diff="144" memory_inc="2994936" memory_diff_inc="1112"/>
+          <iteration time="3" memory="2088" memory_diff="144" memory_inc="2996048" memory_diff_inc="1112"/>
+          <iteration time="3" memory="2232" memory_diff="144" memory_inc="2997160" memory_diff_inc="1112"/>
+          <iteration time="2" memory="2376" memory_diff="144" memory_inc="2998272" memory_diff_inc="1112"/>
+          <iteration time="3" memory="2520" memory_diff="144" memory_inc="2999384" memory_diff_inc="1112"/>
+          <iteration time="3" memory="2664" memory_diff="144" memory_inc="3000624" memory_diff_inc="1240"/>
+          <iteration time="3" memory="2808" memory_diff="144" memory_inc="3001736" memory_diff_inc="1112"/>
+          <iteration time="3" memory="2952" memory_diff="144" memory_inc="3002848" memory_diff_inc="1112"/>
+          <iteration time="3" memory="3096" memory_diff="144" memory_inc="3003968" memory_diff_inc="1120"/>
+          <iteration time="3" memory="3240" memory_diff="144" memory_inc="3005088" memory_diff_inc="1120"/>
+          <iteration time="3" memory="3384" memory_diff="144" memory_inc="3006208" memory_diff_inc="1120"/>
+          <iteration time="3" memory="3528" memory_diff="144" memory_inc="3007336" memory_diff_inc="1128"/>
+          <iteration time="3" memory="3672" memory_diff="144" memory_inc="3008432" memory_diff_inc="1096"/>
+          <iteration time="3" memory="3816" memory_diff="144" memory_inc="3009544" memory_diff_inc="1112"/>
+          <iteration time="3" memory="3960" memory_diff="144" memory_inc="3010656" memory_diff_inc="1112"/>
+          <iteration time="3" memory="4104" memory_diff="144" memory_inc="3011768" memory_diff_inc="1112"/>
+          <iteration time="3" memory="4248" memory_diff="144" memory_inc="3012880" memory_diff_inc="1112"/>
+          <iteration time="3" memory="4392" memory_diff="144" memory_inc="3013992" memory_diff_inc="1112"/>
+          <iteration time="3" memory="4536" memory_diff="144" memory_inc="3015104" memory_diff_inc="1112"/>
+          <iteration time="3" memory="4680" memory_diff="144" memory_inc="3016224" memory_diff_inc="1120"/>
+          <iteration time="3" memory="4824" memory_diff="144" memory_inc="3017328" memory_diff_inc="1104"/>
+          <iteration time="3" memory="4968" memory_diff="144" memory_inc="3018720" memory_diff_inc="1392"/>
+          <iteration time="3" memory="5112" memory_diff="144" memory_inc="3019808" memory_diff_inc="1088"/>
+          <iteration time="3" memory="5256" memory_diff="144" memory_inc="3020944" memory_diff_inc="1136"/>
+          <iteration time="3" memory="5400" memory_diff="144" memory_inc="3022032" memory_diff_inc="1088"/>
+        </iterations>
+      </subject>
+    </benchmark>
+    <benchmark class="IsolatedParameterCase">
+      <subject name="benchIterationIsolation" description="randomBench">
+        <iterations>
+          <parameter name="hello" value="Look &quot;I am using double quotes&quot;"/>
+          <parameter name="goodbye" value="Look 'I am use $dollars&quot;"/>
+          <iteration time="4" memory="176" memory_diff="176" memory_inc="3000392" memory_diff_inc="28616"/>
+          <iteration time="3" memory="176" memory_diff="176" memory_inc="3000392" memory_diff_inc="28616"/>
+          <iteration time="3" memory="176" memory_diff="176" memory_inc="3000392" memory_diff_inc="28616"/>
+          <iteration time="3" memory="176" memory_diff="176" memory_inc="3000392" memory_diff_inc="28616"/>
+          <iteration time="4" memory="176" memory_diff="176" memory_inc="3000392" memory_diff_inc="28616"/>
+        </iterations>
+      </subject>
+    </benchmark>
+    <benchmark class="IsolatedCase">
+      <subject name="benchIterationIsolation" description="5 iterations in isolation">
+        <iterations>
+          <iteration time="83" memory="200" memory_diff="200" memory_inc="6609832" memory_diff_inc="2736"/>
+          <iteration time="16" memory="344" memory_diff="144" memory_inc="6610928" memory_diff_inc="1096"/>
+          <iteration time="13" memory="488" memory_diff="144" memory_inc="6612040" memory_diff_inc="1112"/>
+          <iteration time="13" memory="632" memory_diff="144" memory_inc="6613152" memory_diff_inc="1112"/>
+          <iteration time="13" memory="776" memory_diff="144" memory_inc="6614264" memory_diff_inc="1112"/>
+        </iterations>
+      </subject>
+      <subject name="benchIterationsIsolation" description="Set of 5 iterations in isolation">
+        <iterations>
+          <iteration time="19" memory="200" memory_diff="200" memory_inc="6616536" memory_diff_inc="2784"/>
+          <iteration time="14" memory="344" memory_diff="144" memory_inc="6617632" memory_diff_inc="1096"/>
+          <iteration time="14" memory="488" memory_diff="144" memory_inc="6618744" memory_diff_inc="1112"/>
+          <iteration time="16" memory="632" memory_diff="144" memory_inc="6619856" memory_diff_inc="1112"/>
+          <iteration time="26" memory="776" memory_diff="144" memory_inc="6620968" memory_diff_inc="1112"/>
+        </iterations>
+      </subject>
+    </benchmark>
+    <benchmark class="BenchmarkCase">
+      <subject name="benchRandom" description="randomBench">
+        <iterations>
+          <iteration time="44994" memory="176" memory_diff="176" memory_inc="6625128" memory_diff_inc="2760"/>
+        </iterations>
+      </subject>
+      <subject name="benchDoNothing" description="Do nothing three times">
+        <iterations>
+          <iteration time="6" memory="144" memory_diff="144" memory_inc="6627328" memory_diff_inc="2728"/>
+          <iteration time="4" memory="288" memory_diff="144" memory_inc="6628424" memory_diff_inc="1096"/>
+          <iteration time="4" memory="432" memory_diff="144" memory_inc="6629536" memory_diff_inc="1112"/>
+        </iterations>
+      </subject>
+      <subject name="benchParameterized" description="Parameterized bench mark">
+        <iterations>
+          <parameter name="length" value="1"/>
+          <parameter name="strategy" value="left"/>
+          <iteration time="3" memory="144" memory_diff="144" memory_inc="6634584" memory_diff_inc="5640"/>
+        </iterations>
+        <iterations>
+          <parameter name="length" value="2"/>
+          <parameter name="strategy" value="left"/>
+          <iteration time="3" memory="288" memory_diff="144" memory_inc="6636504" memory_diff_inc="1920"/>
+        </iterations>
+        <iterations>
+          <parameter name="length" value="1"/>
+          <parameter name="strategy" value="right"/>
+          <iteration time="3" memory="432" memory_diff="144" memory_inc="6638440" memory_diff_inc="1936"/>
+        </iterations>
+        <iterations>
+          <parameter name="length" value="2"/>
+          <parameter name="strategy" value="right"/>
+          <iteration time="2" memory="576" memory_diff="144" memory_inc="6640376" memory_diff_inc="1936"/>
+        </iterations>
+      </subject>
+    </benchmark>
+  </suite>
+</phpbench>

--- a/tests/Functional/benchmarks/ArrayKeysCase.php
+++ b/tests/Functional/benchmarks/ArrayKeysCase.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace PhpBench\Tests\Functional\benchmarks;
+
+use PhpBench\Benchmark;
+
+class ArrayKeysCase implements Benchmark
+{
+    private $array;
+
+    public function provide()
+    {
+        $this->array = array('one' => 'one', 'two' => 'two', 'three' => 'three');
+    }
+
+    /**
+     * @description isset
+     * @beforeMethod provide
+     * @iterations 1000
+     */
+    public function benchIsset()
+    {
+        array_key_exists('two', $this->array);
+    }
+
+    /**
+     * @description in_array
+     * @beforeMethod provide
+     * @iterations 1000
+     */
+    public function benchInArray()
+    {
+        array_key_exists('two', $this->array);
+    }
+
+    /**
+     * @description array_key_exists
+     * @beforeMethod provide
+     * @iterations 1000
+     */
+    public function benchArrayKeyExists()
+    {
+        array_key_exists('two', $this->array);
+    }
+}

--- a/tests/Functional/benchmarks/IsolatedCase.php
+++ b/tests/Functional/benchmarks/IsolatedCase.php
@@ -17,20 +17,22 @@ class IsolatedCase implements Benchmark
     /**
      * @description 5 iterations in isolation
      * @iterations 5
-     * @processIsolation iteration
      */
     public function benchIterationIsolation()
     {
-        usleep(1);
+        $handle = fopen(sys_get_temp_dir() . '/phpbench_isolationtest', 'a');
+        fwrite($handle, getmypid() . PHP_EOL);
+        fclose($handle);
     }
 
     /**
      * @description Set of 5 iterations in isolation
      * @iterations 5
-     * @processIsolation iterations
      */
     public function benchIterationsIsolation()
     {
-        usleep(1);
+        $handle = fopen(sys_get_temp_dir() . '/phpbench_isolationtest', 'a');
+        fwrite($handle, getmypid() . PHP_EOL);
+        fclose($handle);
     }
 }

--- a/tests/Functional/benchmarks/IsolatedCase.php
+++ b/tests/Functional/benchmarks/IsolatedCase.php
@@ -15,21 +15,23 @@ use PhpBench\Benchmark;
 class IsolatedCase implements Benchmark
 {
     /**
-     * @description randomBench
+     * @description 5 iterations in isolation
      * @iterations 5
      * @processIsolation iteration
      */
-    public function benchIterationIsolation(Iteration $iteration)
+    public function benchIterationIsolation()
     {
+        usleep(1);
     }
 
     /**
-     * @description randomBench
+     * @description Set of 5 iterations in isolation
      * @iterations 5
      * @processIsolation iterations
      */
-    public function benchIterationsIsolation(Iteration $iteration)
+    public function benchIterationsIsolation()
     {
+        usleep(1);
     }
 }
 

--- a/tests/Functional/benchmarks/IsolatedCase.php
+++ b/tests/Functional/benchmarks/IsolatedCase.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the PHP Bench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PhpBench\Benchmark\Iteration;
+use PhpBench\Benchmark;
+
+class IsolatedCase implements Benchmark
+{
+    /**
+     * @description randomBench
+     * @iterations 5
+     * @processIsolation iteration
+     */
+    public function benchIterationIsolation(Iteration $iteration)
+    {
+    }
+
+    /**
+     * @description randomBench
+     * @iterations 5
+     * @processIsolation iterations
+     */
+    public function benchIterationsIsolation(Iteration $iteration)
+    {
+    }
+}
+

--- a/tests/Functional/benchmarks/IsolatedCase.php
+++ b/tests/Functional/benchmarks/IsolatedCase.php
@@ -34,4 +34,3 @@ class IsolatedCase implements Benchmark
         usleep(1);
     }
 }
-

--- a/tests/Functional/benchmarks/IsolatedParametersCase.php
+++ b/tests/Functional/benchmarks/IsolatedParametersCase.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the PHP Bench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PhpBench\Benchmark\Iteration;
+use PhpBench\Benchmark;
+
+class IsolatedParameterCase implements Benchmark
+{
+    /**
+     * @description randomBench
+     * @iterations 5
+     * @processIsolation iteration
+     * @paramProvider provideParams
+     */
+    public function benchIterationIsolation()
+    {
+    }
+
+    public function provideParams()
+    {
+        return array(
+            array(
+                'hello' => 'Look "I am using double quotes"',
+                'goodbye' => 'Look \'I am using single quotes\'"',
+                'goodbye' => 'Look \'I am use $dollars"',
+            )
+        );
+    }
+}
+

--- a/tests/Functional/benchmarks/IsolatedParametersCase.php
+++ b/tests/Functional/benchmarks/IsolatedParametersCase.php
@@ -31,8 +31,7 @@ class IsolatedParameterCase implements Benchmark
                 'hello' => 'Look "I am using double quotes"',
                 'goodbye' => 'Look \'I am using single quotes\'"',
                 'goodbye' => 'Look \'I am use $dollars"',
-            )
+            ),
         );
     }
 }
-

--- a/tests/Unit/Benchmark/ParserTest.php
+++ b/tests/Unit/Benchmark/ParserTest.php
@@ -46,6 +46,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 * @beforeMethod afterBeforeMe
 * @paramProvider provideParam
 * @iterations  3
+* @processIsolation iteration
 */
 EOT
                 ,
@@ -54,6 +55,7 @@ EOT
                     'iterations' => 3,
                     'beforeMethod' => array('beforeMe', 'afterBeforeMe'),
                     'paramProvider' => array('provideParam'),
+                    'processIsolation' => 'iteration',
                 ),
             ),
             array(
@@ -67,6 +69,7 @@ EOT
                     'beforeMethod' => array(),
                     'paramProvider' => array(),
                     'iterations' => 1,
+                    'processIsolation' => false,
                 ),
             ),
         );
@@ -97,5 +100,24 @@ EOT
     public function testMoreThatOneIterationAnnotation()
     {
         $this->markTestIncomplete('Do this');
+    }
+
+    /**
+     * Its should throw an exception if the process isolation is not valid
+     *
+     * @expectedException PhpBench\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Process isolation must be one of "iteration", "iterations"
+     */
+    public function testInvalidProcessIsolation()
+    {
+        $doc = <<<EOT
+/**
+* @description Hello
+* @processIsolation iterationasd
+*/
+EOT
+        ;
+
+        $this->parser->parseMethodDoc($doc);
     }
 }

--- a/tests/Unit/Benchmark/ParserTest.php
+++ b/tests/Unit/Benchmark/ParserTest.php
@@ -103,7 +103,7 @@ EOT
     }
 
     /**
-     * Its should throw an exception if the process isolation is not valid
+     * Its should throw an exception if the process isolation is not valid.
      *
      * @expectedException PhpBench\Exception\InvalidArgumentException
      * @expectedExceptionMessage Process isolation must be one of "iteration", "iterations"

--- a/tests/Unit/Benchmark/RunnerTest.php
+++ b/tests/Unit/Benchmark/RunnerTest.php
@@ -55,6 +55,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         $this->subject->getMethodName()->willReturn('benchFoo');
         $this->subject->getBeforeMethods()->willReturn(array('beforeFoo'));
         $this->subject->getDescription()->willReturn('Hello world');
+        $this->subject->getProcessIsolation()->willReturn(false);
 
         $result = $this->runner->runAll();
 
@@ -83,6 +84,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         $this->subject->getNbIterations()->willReturn(1);
         $this->subject->getParameterProviders()->willReturn(array());
         $this->subject->getBeforeMethods()->willReturn(array('beforeFooNotExisting'));
+        $this->subject->getProcessIsolation()->willReturn(false);
 
         $this->runner->runAll();
     }
@@ -104,6 +106,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         ));
         $this->subject->getNbIterations()->willReturn(1);
         $this->subject->getParameterProviders()->willReturn(array('notExistingParam'));
+        $this->subject->getProcessIsolation()->willReturn(false);
 
         $this->runner->runAll();
     }
@@ -124,6 +127,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         $this->subject->getMethodName()->willReturn('benchFoo');
         $this->subject->getDescription()->willReturn('benchFoo');
         $this->subject->getNbIterations()->willReturn(0);
+        $this->subject->getProcessIsolation()->willReturn(false);
 
         $this->runner->runAll();
 

--- a/tests/Unit/Benchmark/RunnerTest.php
+++ b/tests/Unit/Benchmark/RunnerTest.php
@@ -14,7 +14,6 @@ namespace PhpBench\Tests\Benchmark;
 use PhpBench\Benchmark\Runner;
 use PhpBench\Benchmark;
 use PhpBench\Benchmark\Iteration;
-use PhpBench\Exception\InvalidArgumentException;
 
 class RunnerTest extends \PHPUnit_Framework_TestCase
 {
@@ -67,7 +66,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should throw an exception if a before method does not exist
+     * It should throw an exception if a before method does not exist.
      *
      * @expectedException PhpBench\Exception\InvalidArgumentException
      * @expectedExceptionMessage Unknown bench benchmark method "beforeFooNotExisting"
@@ -90,7 +89,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should throw an exception if a parameter provider does not exist
+     * It should throw an exception if a parameter provider does not exist.
      *
      * @expectedException PhpBench\Exception\InvalidArgumentException
      * @expectedExceptionMessage Unknown param provider "notExistingParam" for bench benchmark
@@ -112,7 +111,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * The magic tearDown and setUp should be called
+     * The magic tearDown and setUp should be called.
      */
     public function testSetUpAndTearDown()
     {
@@ -135,6 +134,36 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->case->tearDownCalled);
     }
 
+    /**
+     * The magic tearDown and setUp should not be called if setUpTearDown is false.
+     */
+    public function testSetUpAndTearDownDisabled()
+    {
+        $runner = new Runner(
+            $this->collectionBuilder->reveal(), $this->subjectBuilder->reveal(),
+            $this->logger->reveal(),
+            false,
+            false
+        );
+
+        $this->collectionBuilder->buildCollection()->willReturn($this->collection);
+        $this->collection->getBenchmarks()->willReturn(array(
+            $this->case,
+        ));
+        $this->subjectBuilder->buildSubjects($this->case)->willReturn(array(
+            $this->subject->reveal(),
+        ));
+        $this->subject->getParameterProviders()->willReturn(array());
+        $this->subject->getMethodName()->willReturn('benchFoo');
+        $this->subject->getDescription()->willReturn('benchFoo');
+        $this->subject->getNbIterations()->willReturn(0);
+        $this->subject->getProcessIsolation()->willReturn(false);
+
+        $runner->runAll();
+
+        $this->assertFalse($this->case->setUpCalled);
+        $this->assertFalse($this->case->tearDownCalled);
+    }
 }
 
 class RunnerTestBenchCase implements Benchmark

--- a/tests/Unit/Benchmark/RunnerTest.php
+++ b/tests/Unit/Benchmark/RunnerTest.php
@@ -102,6 +102,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         $this->subjectBuilder->buildSubjects($this->case)->willReturn(array(
             $this->subject->reveal(),
         ));
+        $this->subject->getNbIterations()->willReturn(1);
         $this->subject->getParameterProviders()->willReturn(array('notExistingParam'));
 
         $this->runner->runAll();

--- a/tests/Unit/ReportGenerator/ConsoleTableReportGeneratorTest.php
+++ b/tests/Unit/ReportGenerator/ConsoleTableReportGeneratorTest.php
@@ -1,9 +1,17 @@
 <?php
 
+/*
+ * This file is part of the PHP Bench package
+ *
+ * (c) Daniel Leech <daniel@dantleech.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace PhpBench\Tests\Unit\ReportGenerator;
 
 use PhpBench\ReportGenerator\ConsoleTableReportGenerator;
-use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Console\Output\BufferedOutput;
 
@@ -26,16 +34,16 @@ class ConsoleTableReportGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->iterationResult1 = $this->prophesize('PhpBench\Result\IterationResult');
 
         $this->suiteResult->getBenchmarkResults()->willReturn(array(
-            $this->benchmarkResult->reveal()
+            $this->benchmarkResult->reveal(),
         ));
         $this->benchmarkResult->getSubjectResults()->willReturn(array(
-            $this->subjectResult->reveal()
+            $this->subjectResult->reveal(),
         ));
         $this->subjectResult->getIterationsResults()->willReturn(array(
-            $this->iterationsResult->reveal()
+            $this->iterationsResult->reveal(),
         ));
         $this->iterationsResult->getIterationResults()->willReturn(array(
-            $this->iterationResult1
+            $this->iterationResult1,
         ));
 
         $this->benchmarkResult->getClass()->willReturn('AcmeClass');
@@ -44,7 +52,7 @@ class ConsoleTableReportGeneratorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * It should render non scalar parameter values
+     * It should render non scalar parameter values.
      */
     public function testNonScalarParameterValue()
     {

--- a/tests/Unit/Result/Dumper/XmlDumperTest.php
+++ b/tests/Unit/Result/Dumper/XmlDumperTest.php
@@ -62,7 +62,7 @@ EOT;
     {
         $iteration1 = new IterationResult(array('time' => 100));
         $iterations = new IterationsResult(array($iteration1), array(
-            'foo' => 'bar', 
+            'foo' => 'bar',
             'array' => array('one', 'two'),
             'assoc_array' => array(
                 'one' => 'two',

--- a/tests/Unit/Result/Dumper/XmlDumperTest.php
+++ b/tests/Unit/Result/Dumper/XmlDumperTest.php
@@ -36,6 +36,14 @@ class XmlDumperTest extends \PHPUnit_Framework_TestCase
       <subject name="mySubject" description="My Subject's description">
         <iterations>
           <parameter name="foo" value="bar"/>
+          <parameter name="array" multiple="1">
+            <parameter name="0" value="one"/>
+            <parameter name="1" value="two"/>
+          </parameter>
+          <parameter name="assoc_array" multiple="1">
+            <parameter name="one" value="two"/>
+            <parameter name="three" value="four"/>
+          </parameter>
           <iteration time="100"/>
         </iterations>
       </subject>
@@ -53,7 +61,14 @@ EOT;
     protected function getSuite()
     {
         $iteration1 = new IterationResult(array('time' => 100));
-        $iterations = new IterationsResult(array($iteration1), array('foo' => 'bar'));
+        $iterations = new IterationsResult(array($iteration1), array(
+            'foo' => 'bar', 
+            'array' => array('one', 'two'),
+            'assoc_array' => array(
+                'one' => 'two',
+                'three' => 'four',
+            ),
+        ));
         $subject = new SubjectResult('mySubject', 'My Subject\'s description', array($iterations));
         $benchmark = new BenchmarkResult('Benchmark\Class', array($subject));
         $suite = new SuiteResult(array($benchmark));

--- a/tests/Unit/Result/Loader/XmlLoaderTest.php
+++ b/tests/Unit/Result/Loader/XmlLoaderTest.php
@@ -22,6 +22,9 @@ class XmlLoaderTest extends XmlDumperTest
         $this->loader = new XmlLoader();
     }
 
+    /**
+     * Its should load an XML document and return the suite
+     */
     public function testLoad()
     {
         $result = $this->testDump();
@@ -30,5 +33,15 @@ class XmlLoaderTest extends XmlDumperTest
             $this->getSuite(),
             $suite
         );
+    }
+
+    /**
+     * Its should thow an exception if the XML is invalid
+     *
+     * @expectedException RuntimeException
+     */
+    public function testLoadInvalid()
+    {
+        $this->loader->load('hai');
     }
 }

--- a/tests/Unit/Result/Loader/XmlLoaderTest.php
+++ b/tests/Unit/Result/Loader/XmlLoaderTest.php
@@ -23,7 +23,7 @@ class XmlLoaderTest extends XmlDumperTest
     }
 
     /**
-     * Its should load an XML document and return the suite
+     * Its should load an XML document and return the suite.
      */
     public function testLoad()
     {
@@ -36,7 +36,7 @@ class XmlLoaderTest extends XmlDumperTest
     }
 
     /**
-     * Its should thow an exception if the XML is invalid
+     * Its should thow an exception if the XML is invalid.
      *
      * @expectedException RuntimeException
      */

--- a/tests/phpbench
+++ b/tests/phpbench
@@ -5,6 +5,7 @@ $configuration = new PhpBench\Configuration();
 $configuration->setPath(__DIR__ . '/../tests/Functional/benchmarks');
 $configuration->addReport(array(
     'name' => 'console_table',
+    'time_format' => 'integer',
     'revolutions' => true,
     'memory' => true,
     'memory_inc' => true,

--- a/tests/phpbench
+++ b/tests/phpbench
@@ -1,0 +1,12 @@
+<?php
+
+require(__DIR__ . '/../vendor/autoload.php');
+$configuration = new PhpBench\Configuration();
+$configuration->setPath(__DIR__ . '/../tests/Functional/benchmarks');
+$configuration->addReport(array(
+    'name' => 'console_table',
+    'revolutions' => true,
+    'memory' => true,
+));
+
+return $configuration;

--- a/tests/phpbench
+++ b/tests/phpbench
@@ -7,6 +7,7 @@ $configuration->addReport(array(
     'name' => 'console_table',
     'revolutions' => true,
     'memory' => true,
+    'memory_inc' => true,
 ));
 
 return $configuration;


### PR DESCRIPTION
Support for running benchmarks in separate processes.

Allows both running each individual iteration in isolation in addition to running sets of parameterized iterations in isolation.

Process isolation can be triggered via annotations or globally with the `--processisolation` option.

In addition this PR adds options for globally specifying parameters and the number of iterations to run for each test.