### PR TITLE
Refactoring reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@ CHANGELOG
 
 - [Console Report] Function `avg` renamed to `mean`
 - [Console Report] Aggregate shows min and max deviation
+- Bumped minimum version of PHP to 5.4

--- a/README.md
+++ b/README.md
@@ -57,7 +57,13 @@ following annotations:
 
 **singular**
 
-A description of the benchmark subject
+A description of the benchmark subject.
+
+### @groups
+
+**plural**
+
+Assign the annotated method or class instance in the named group.
 
 ### @revs
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": "~5.3",
+        "php": "~5.4",
         "symfony/console": "~2.4",
         "symfony/finder": "~2.4",
         "symfony/options-resolver": "~2.4",

--- a/examples/CostOfReflectionBench.php
+++ b/examples/CostOfReflectionBench.php
@@ -6,6 +6,7 @@ use PhpBench\Benchmark;
  * @beforeMethod init
  * @revs 10000
  * @iterations 4
+ * @group cost_of_reflection
  */
 class CostOfReflectionBench implements Benchmark
 {

--- a/examples/phpbench
+++ b/examples/phpbench
@@ -5,9 +5,6 @@ require_once(__DIR__ . '/../vendor/autoload.php');
 $config = new PhpBench\Configuration();
 $config->addReport(array(
     'name' => 'console_table',
-));
-$config->addReport(array(
-    'name' => 'console_table',
     'aggregate_iterations' => true,
     'mean_time' => true,
     'mean_rps' => true,

--- a/lib/Benchmark/Parser.php
+++ b/lib/Benchmark/Parser.php
@@ -25,16 +25,19 @@ class Parser
             'iterations' => array(),
             'description' => array(),
             'processIsolation' => array(),
+            'group' => array(),
             'revs' => array(),
         );
 
+        // singular annotations
         foreach (array('description', 'iterations', 'processIsolation') as $key) {
             if (isset($defaults[$key]) && $defaults[$key]) {
                 $meta[$key][] = $defaults[$key];
             }
         }
 
-        foreach (array('beforeMethod', 'paramProvider', 'revs') as $key) {
+        // plural annotations
+        foreach (array('beforeMethod', 'paramProvider', 'revs', 'group') as $key) {
             if (isset($defaults[$key]) && $defaults[$key]) {
                 $meta[$key] = $defaults[$key];
             }

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -142,6 +142,7 @@ class Runner
         $subjectResult = new SubjectResult(
             $subject->getMethodName(),
             $subject->getDescription(),
+            $subject->getGroups(),
             $iterationsResults
         );
 

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -188,9 +188,10 @@ class Runner
 
         for ($index = 0; $index < $iterationCount; $index++) {
             $command = sprintf(
-                'php %s run %s --subject=%s --nosetup --dump --parameters=%s --iterations=%d --processisolation=none',
+                'php %s run %s --subject=%s --subject=%s --nosetup --dump --parameters=%s --iterations=%d --processisolation=none',
                 $bin,
                 $reflection->getFileName(),
+                $subject->getMethodName(),
                 $subject->getMethodName(),
                 escapeshellarg(json_encode($parameters)),
                 $nbIterations

--- a/lib/Benchmark/Runner.php
+++ b/lib/Benchmark/Runner.php
@@ -188,7 +188,7 @@ class Runner
 
         for ($index = 0; $index < $iterationCount; $index++) {
             $command = sprintf(
-                'php %s run %s --subject=%s --subject=%s --nosetup --dump --parameters=%s --iterations=%d --processisolation=none',
+                'php %s run %s --subject=%s --nosetup --dump --parameters=%s --iterations=%d --processisolation=none',
                 $bin,
                 $reflection->getFileName(),
                 $subject->getMethodName(),

--- a/lib/Benchmark/Subject.php
+++ b/lib/Benchmark/Subject.php
@@ -20,6 +20,7 @@ class Subject
     private $description;
     private $processIsolation;
     private $revs;
+    private $groups;
 
     public function __construct(
         $methodName,
@@ -28,7 +29,8 @@ class Subject
         $nbIterations,
         array $revs,
         $description,
-        $processIsolation
+        $processIsolation,
+        array $groups
     ) {
         $this->methodName = $methodName;
         $this->beforeMethods = $beforeMethods;
@@ -37,6 +39,7 @@ class Subject
         $this->revs = $revs;
         $this->description = $description;
         $this->processIsolation = $processIsolation;
+        $this->groups = $groups;
     }
 
     public function getBeforeMethods()
@@ -72,5 +75,10 @@ class Subject
     public function getRevs()
     {
         return $this->revs;
+    }
+
+    public function getGroups() 
+    {
+        return $this->groups;
     }
 }

--- a/lib/Benchmark/SubjectBuilder.php
+++ b/lib/Benchmark/SubjectBuilder.php
@@ -49,7 +49,8 @@ class SubjectBuilder
                 $meta['iterations'],
                 $meta['revs'],
                 $meta['description'],
-                $meta['processIsolation']
+                $meta['processIsolation'],
+                $meta['group']
             );
         }
 

--- a/lib/Benchmark/SubjectBuilder.php
+++ b/lib/Benchmark/SubjectBuilder.php
@@ -16,12 +16,14 @@ use PhpBench\Benchmark;
 class SubjectBuilder
 {
     private $parser;
-    private $subject;
+    private $subjects;
+    private $groups;
 
-    public function __construct($subject = null)
+    public function __construct(array $subjects = array(), array $groups = array())
     {
         $this->parser = new Parser();
-        $this->subject = $subject;
+        $this->subjects = $subjects;
+        $this->groups = $groups;
     }
 
     public function buildSubjects(Benchmark $case)
@@ -36,11 +38,15 @@ class SubjectBuilder
                 continue;
             }
 
-            if ($this->subject && $method->getName() !== $this->subject) {
+            if ($this->subjects && false === in_array($method->getName(), $this->subjects)) {
                 continue;
             }
 
             $meta = $this->parser->parseDoc($method->getDocComment(), $defaults);
+
+            if ($this->groups && 0 === count(array_intersect($this->groups, $meta['group']))) {
+                continue;
+            }
 
             $subjects[] = new Subject(
                 $method->getName(),

--- a/lib/Console/Command/RunCommand.php
+++ b/lib/Console/Command/RunCommand.php
@@ -42,7 +42,8 @@ EOT
         );
         $this->addArgument('path', InputArgument::OPTIONAL, 'Path to benchmark(s)');
         $this->addOption('report', array(), InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Report name or configuration in JSON format');
-        $this->addOption('subject', null, InputOption::VALUE_REQUIRED, 'Subject to run');
+        $this->addOption('subject', array(), InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Subject to run (can be specified multiple times)');
+        $this->addOption('group', array(), InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Group to run (can be specified multiple times)');
         $this->addOption('dumpfile', 'df', InputOption::VALUE_OPTIONAL, 'Dump XML result to named file');
         $this->addOption('dump', null, InputOption::VALUE_NONE, 'Dump XML result to stdout and suppress all other output');
         $this->addOption('parameters', null, InputOption::VALUE_REQUIRED, 'Override parameters to use in (all) benchmarks');
@@ -108,7 +109,8 @@ EOT
             );
         }
 
-        $subject = $input->getOption('subject');
+        $subjects = $input->getOption('subject');
+        $groups = $input->getOption('group');
         $dumpfile = $input->getOption('dumpfile');
 
         if (false === $enableGc) {
@@ -116,7 +118,7 @@ EOT
         }
 
         $startTime = microtime(true);
-        $result = $this->executeBenchmarks($path, $subject, $noSetup, $parameters, $iterations, $revs, $processIsolation, $configFile, $progressLogger);
+        $result = $this->executeBenchmarks($path, $subjects, $groups, $noSetup, $parameters, $iterations, $revs, $processIsolation, $configFile, $progressLogger);
 
         $consoleOutput->writeln('');
         if ($dumpfile) {
@@ -149,7 +151,7 @@ EOT
         return $dumper->dump($result);
     }
 
-    private function executeBenchmarks($path, $subject, $noSetup, $parameters, $iterations, $revs, $processIsolation, $configFile, ProgressLogger $progressLogger)
+    private function executeBenchmarks($path, array $subjects, array $groups, $noSetup, $parameters, $iterations, $revs, $processIsolation, $configFile, ProgressLogger $progressLogger)
     {
         $finder = new Finder();
 
@@ -169,7 +171,7 @@ EOT
         }
 
         $benchFinder = new CollectionBuilder($finder);
-        $subjectBuilder = new SubjectBuilder($subject);
+        $subjectBuilder = new SubjectBuilder($subjects, $groups);
 
         $benchRunner = new Runner(
             $benchFinder,

--- a/lib/PhpBench.php
+++ b/lib/PhpBench.php
@@ -13,5 +13,5 @@ namespace PhpBench;
 
 class PhpBench
 {
-    const VERSION = '0.1';
+    const VERSION = '0.2';
 }

--- a/lib/ReportGenerator/BaseTabularReportGenerator.php
+++ b/lib/ReportGenerator/BaseTabularReportGenerator.php
@@ -69,6 +69,7 @@ abstract class BaseTabularReportGenerator implements ReportGenerator
             $defaults,
             array(
                 'aggregate_iterations' => false,
+                'groups' => array(),
                 'precision' => 6,
                 'time_format' => 'fraction',
                 'time' => true,
@@ -106,6 +107,12 @@ abstract class BaseTabularReportGenerator implements ReportGenerator
     private function prepareTables(BenchmarkResult $benchmarkResult, Workspace $workspace, array $options)
     {
         foreach ($benchmarkResult->getSubjectResults() as $subject) {
+
+            // skip if groups were specified and the subject is not in any of the specified groups
+            if ($options['groups'] && 0 === count(array_intersect($options['groups'], $subject->getGroups()))) {
+                continue;
+            }
+
             $table = $workspace->createAndAddTable();
             $table->setTitle($benchmarkResult->getClass() . '->' . $subject->getName());
             $table->setDescription($subject->getDescription());

--- a/lib/ReportGenerator/ConsoleTableReportGenerator.php
+++ b/lib/ReportGenerator/ConsoleTableReportGenerator.php
@@ -15,10 +15,11 @@ use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\OutputInterface;
 use PhpBench\Result\SuiteResult;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use DTL\Cellular\Workspace;
 
 class ConsoleTableReportGenerator extends BaseTabularReportGenerator
 {
-    public function doGenerate(SuiteResult $suite, OutputInterface $output, array $options)
+    public function doGenerate(Workspace $workspace, OutputInterface $output, array $options)
     {
         $output = $output;
         $output->getFormatter()->setStyle(
@@ -31,20 +32,16 @@ class ConsoleTableReportGenerator extends BaseTabularReportGenerator
             'dark', new OutputFormatterStyle('black', null, array('bold'))
         );
 
-        foreach ($suite->getBenchmarkResults() as $benchmark) {
-            foreach ($benchmark->getSubjectResults() as $subject) {
-                $output->writeln(sprintf(
-                    '<comment>%s#%s()</comment>: %s',
-                    $benchmark->getClass(),
-                    $subject->getName(),
-                    $subject->getDescription()
-                ));
+        foreach ($workspace->getTables() as $data) {
+            $output->writeln(sprintf(
+                '<comment>%s</comment>: %s',
+                $data->getTitle(),
+                $data->getDescription()
+            ));
 
-                $data = $this->prepareData($subject, $options);
-                $this->renderData($output, $data, $options);
+            $this->renderData($output, $data, $options);
 
-                $output->writeln('');
-            }
+            $output->writeln('');
         }
     }
 

--- a/lib/Result/Dumper/XmlDumper.php
+++ b/lib/Result/Dumper/XmlDumper.php
@@ -76,6 +76,12 @@ class XmlDumper
         $subjectEl->setAttribute('name', $subjectResult->getName());
         $subjectEl->setAttribute('description', $subjectResult->getDescription());
 
+        foreach ($subjectResult->getGroups() as $group) {
+            $groupEl = $dom->createElement('group');
+            $groupEl->setAttribute('name', $group);
+            $subjectEl->appendChild($groupEl);
+        }
+
         foreach ($subjectResult->getIterationsResults() as $iterationsResults) {
             $iterationsResultsEl = $this->dumpIterations($iterationsResults, $dom);
             $subjectEl->appendChild($iterationsResultsEl);

--- a/lib/Result/Loader/XmlLoader.php
+++ b/lib/Result/Loader/XmlLoader.php
@@ -58,10 +58,21 @@ class XmlLoader
             $name = $subjectEl->getAttribute('name');
             $description = $subjectEl->getAttribute('description');
             $iterationsResults = $this->getIterationsResults($xpath, $subjectEl);
-            $subjectResults[] = new SubjectResult($name, $description, $iterationsResults);
+            $groups = $this->getGroups($xpath, $subjectEl);
+            $subjectResults[] = new SubjectResult($name, $description, $groups, $iterationsResults);
         }
 
         return $subjectResults;
+    }
+
+    private function getGroups(\DOMXPath $xpath, \DOMElement $subjectEl)
+    {
+        $groups = array();
+        foreach ($xpath->query('./group', $subjectEl) as $groupEl) {
+            $groups[] = $groupEl->getAttribute('name');
+        }
+
+        return $groups;
     }
 
     private function getIterationsResults(\DOMXPath $xpath, \DOMElement $subjectEl)

--- a/lib/Result/SubjectResult.php
+++ b/lib/Result/SubjectResult.php
@@ -15,13 +15,15 @@ class SubjectResult
 {
     private $name;
     private $description;
+    private $groups;
     private $iterationsResults;
 
-    public function __construct($name, $description, array $iterationsResults)
+    public function __construct($name, $description, array $groups, array $iterationsResults)
     {
         $this->iterationsResults = $iterationsResults;
         $this->name = $name;
         $this->description = $description;
+        $this->groups = $groups;
     }
 
     public function getName()
@@ -37,5 +39,10 @@ class SubjectResult
     public function getIterationsResults()
     {
         return $this->iterationsResults;
+    }
+
+    public function getGroups() 
+    {
+        return $this->groups;
     }
 }

--- a/tests/Functional/Console/Command/RunCommandTest.php
+++ b/tests/Functional/Console/Command/RunCommandTest.php
@@ -191,7 +191,7 @@ class RunCommandTest extends BaseCommandTestCase
     public function testOverrideIterations()
     {
         $tester = $this->runCommand('run', array(
-            '--subject' => 'benchRandom',
+            '--subject' => array('benchRandom'),
             '--dump' => true,
             '--iterations' => 10,
             'path' => __DIR__ . '/../../benchmarks/BenchmarkBench.php',
@@ -259,5 +259,26 @@ class RunCommandTest extends BaseCommandTestCase
             '--processisolation' => 'iteration',
             'path' => __DIR__ . '/../../benchmarks/IsolatedParametersBench.php',
         ));
+    }
+
+    /**
+     * It should run specified groups
+     */
+    public function testGroups()
+    {
+        $tester = $this->runCommand('run', array(
+            '--group' => array('do_nothing'),
+            '--dump' => true,
+            'path' => __DIR__ . '/../../benchmarks/BenchmarkBench.php',
+        ));
+
+        $this->assertEquals(0, $tester->getStatusCode());
+        $display = $tester->getDisplay();
+        $dom = new \DOMDocument();
+        $dom->loadXml($display);
+        $dom->formatOutput = true;
+        $xpath = new \DOMXPath($dom);
+        $parameters = $xpath->query('//subject');
+        $this->assertEquals(1, $parameters->length);
     }
 }

--- a/tests/Functional/ReportGenerator/BaseTabularReportGeneratorCase.php
+++ b/tests/Functional/ReportGenerator/BaseTabularReportGeneratorCase.php
@@ -100,4 +100,14 @@ abstract class BaseTabularReportGeneratorCase extends BaseReportGeneratorCase
             'deviation' => true,
         ));
     }
+
+    /**
+     * It should allow groups to be specified
+     */
+    public function testGroups()
+    {
+        $this->executeReport($this->getResults(), array(
+            'groups' => array('foo'),
+        ));
+    }
 }

--- a/tests/Functional/benchmarks/BenchmarkBench.php
+++ b/tests/Functional/benchmarks/BenchmarkBench.php
@@ -26,6 +26,7 @@ class BenchmarkBench implements Benchmark
      * @iterations 3
      * @revs 1000
      * @description Do nothing three times
+     * @group do_nothing
      */
     public function benchDoNothing(Iteration $iteration)
     {

--- a/tests/Unit/Benchmark/ParserTest.php
+++ b/tests/Unit/Benchmark/ParserTest.php
@@ -49,6 +49,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
 * @processIsolation iteration
 * @revs 1000
 * @revs 10
+* @group base
 */
 EOT
                 ,
@@ -59,6 +60,7 @@ EOT
                     'paramProvider' => array('provideParam'),
                     'processIsolation' => 'iteration',
                     'revs' => array(1000, 10),
+                    'group' => array('base'),
                 ),
             ),
             array(
@@ -74,6 +76,7 @@ EOT
                     'iterations' => 1,
                     'processIsolation' => false,
                     'revs' => array(1),
+                    'group' => array(),
                 ),
             ),
         );
@@ -112,6 +115,7 @@ EOT
                     'paramProvider' => array('provideParam'),
                     'processIsolation' => 'iteration',
                     'revs' => array(1000, 10),
+                    'group' => array('boo')
                 ),
                 <<<EOT
 /**
@@ -121,6 +125,7 @@ EOT
 * @iterations 3
 * @processIsolation iterations
 * @revs 5
+* @group five
  */
 EOT
                 ,
@@ -131,6 +136,7 @@ EOT
                     'paramProvider' => array('provideParam', 'notherParam'),
                     'processIsolation' => 'iterations',
                     'revs' => array(1000, 10, 5),
+                    'group' => array('boo', 'five'),
                 ),
             ),
             array(
@@ -141,6 +147,7 @@ EOT
                     'paramProvider' => array('provideParam'),
                     'processIsolation' => 'iteration',
                     'revs' => array(1000, 10),
+                    'group' => array('boo'),
                 ),
                 <<<EOT
 /**
@@ -155,6 +162,7 @@ EOT
                     'paramProvider' => array('provideParam'),
                     'processIsolation' => 'iteration',
                     'revs' => array(1000, 10),
+                    'group' => array('boo'),
                 ),
             ),
             array(
@@ -174,6 +182,7 @@ EOT
                     'paramProvider' => array('provideParam'),
                     'processIsolation' => 'iteration',
                     'revs' => array(1000, 10),
+                    'group' => array(),
                 ),
             ),
         );

--- a/tests/Unit/Benchmark/RunnerTest.php
+++ b/tests/Unit/Benchmark/RunnerTest.php
@@ -55,6 +55,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         $this->subject->getMethodName()->willReturn('benchFoo');
         $this->subject->getBeforeMethods()->willReturn(array('beforeFoo'));
         $this->subject->getDescription()->willReturn('Hello world');
+        $this->subject->getGroups()->willReturn(array());
         $this->subject->getProcessIsolation()->willReturn(false);
         $this->subject->getRevs()->willReturn($revs);
 
@@ -154,6 +155,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         $this->subject->getParameterProviders()->willReturn(array());
         $this->subject->getMethodName()->willReturn('benchFoo');
         $this->subject->getDescription()->willReturn('benchFoo');
+        $this->subject->getGroups()->willReturn(array());
         $this->subject->getNbIterations()->willReturn(0);
         $this->subject->getProcessIsolation()->willReturn(false);
         $this->subject->getRevs()->willReturn(array(1));
@@ -186,6 +188,7 @@ class RunnerTest extends \PHPUnit_Framework_TestCase
         $this->subject->getParameterProviders()->willReturn(array());
         $this->subject->getMethodName()->willReturn('benchFoo');
         $this->subject->getDescription()->willReturn('benchFoo');
+        $this->subject->getGroups()->willReturn(array());
         $this->subject->getNbIterations()->willReturn(0);
         $this->subject->getProcessIsolation()->willReturn(false);
         $this->subject->getRevs()->willReturn(array(1));

--- a/tests/Unit/Benchmark/SubjectBuilderTest.php
+++ b/tests/Unit/Benchmark/SubjectBuilderTest.php
@@ -35,6 +35,7 @@ class SubjectBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $subjects);
         $subject = reset($subjects);
 
+        $this->assertEquals(array('group1'), $subject->getGroups());
         $this->assertEquals(array('beforeSelectSql'), $subject->getBeforeMethods());
         $this->assertEquals(array('provideNodes', 'provideColumns'), $subject->getParameterProviders());
         $this->assertEquals(3, $subject->getNbIterations());

--- a/tests/Unit/Benchmark/parsertest/ParserCase.php
+++ b/tests/Unit/Benchmark/parsertest/ParserCase.php
@@ -12,6 +12,9 @@
 use PhpBench\BenchIteration;
 use PhpBench\Benchmark;
 
+/**
+ * @group group1
+ */
 class ParserCase implements Benchmark
 {
     /**

--- a/tests/Unit/Result/Dumper/XmlDumperTest.php
+++ b/tests/Unit/Result/Dumper/XmlDumperTest.php
@@ -34,6 +34,8 @@ class XmlDumperTest extends \PHPUnit_Framework_TestCase
   <suite>
     <benchmark class="Benchmark\Class">
       <subject name="mySubject" description="My Subject's description">
+        <group name="one"/>
+        <group name="two"/>
         <iterations>
           <parameter name="foo" value="bar"/>
           <parameter name="array" multiple="1">
@@ -69,7 +71,7 @@ EOT;
                 'three' => 'four',
             ),
         ));
-        $subject = new SubjectResult('mySubject', 'My Subject\'s description', array($iterations));
+        $subject = new SubjectResult('mySubject', 'My Subject\'s description', array('one', 'two'), array($iterations));
         $benchmark = new BenchmarkResult('Benchmark\Class', array($subject));
         $suite = new SuiteResult(array($benchmark));
 


### PR DESCRIPTION
This PR aims to refactor reports to enable them to operate only groups of tables, for instance to create a summary report.

````
$config->addReport(array(
    'name' => 'console_table',
    'groups' => array('some_group_name'), // tables can be aggregated from multiple benchmarks
    'aggregate' => 'table',
    'deviation' => true,
    'order' => array('rps' => 'desc'),
    'rps' => true
));
````
